### PR TITLE
Add file path support to corpospeak command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,22 @@ The project is .NET 9, and uses Microsoft's System.CommandLine library for build
 
 ### Feature Branch Process
 
-**IMPORTANT**: All new features must be developed in feature branches:
-- Create a new branch for each feature: `git checkout -b feature/feature-name`
-- Feature branch names must be prefixed with `feature/`
-- If you're in the middle of another feature, NEVER start a new one
-- Complete the current feature branch before starting any new work
-- Merge feature branches back to master when complete
+**CRITICAL - ALWAYS CHECK BRANCH FIRST**: All new features must be developed in feature branches:
+- **BEFORE starting any work**: Check current branch with `git status` or `git branch`
+- **Create a new branch for each feature**: `git checkout -b feature/feature-name`
+- **Feature branch names must be prefixed with `feature/`**
+- **If you're in the middle of another feature, NEVER start a new one**
+- **Complete the current feature branch before starting any new work**
+- **Merge feature branches back to master when complete**
+- **NEVER add unrelated features to existing feature branches**
+
+**Branch Workflow Checklist**:
+1. Check current branch status
+2. If on existing feature branch, complete that work first
+3. Create new feature branch for new work
+4. Implement feature on correct branch
+5. Test and validate changes
+6. Create PR when feature is complete
 
 ### Version Management
 

--- a/Commands/OpenAiCommand.cs
+++ b/Commands/OpenAiCommand.cs
@@ -166,7 +166,7 @@ public static class OpenAiCommand
 
         var sourceOption = new Option<string>(
             aliases: ["--source"],
-            description: "The source text to rewrite")
+            description: "The source text to rewrite (or path to file containing the text)")
         {
             IsRequired = true
         };
@@ -180,7 +180,7 @@ public static class OpenAiCommand
 
         var userMessagesOption = new Option<string[]>(
             aliases: ["--user-messages"],
-            description: "Optional user messages to learn idiolect from (multiple values allowed)")
+            description: "Optional user messages to learn idiolect from (text or file paths, multiple values allowed)")
         {
             IsRequired = false,
             AllowMultipleArgumentsPerToken = true

--- a/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>2.2.1</Version>
+    <Version>2.3.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.</Description>
     <PackageTags>cli;toolkit;strings;search;interpreters;steganography;openai</PackageTags>

--- a/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.</Description>
     <PackageTags>cli;toolkit;strings;search;interpreters;steganography;openai</PackageTags>


### PR DESCRIPTION
## Summary
- Extended `--source` argument to accept file paths in addition to direct text
- Extended `--user-messages` argument to accept file paths in addition to direct text  
- Added automatic file reading functionality with fallback to direct text
- Enhanced CLAUDE.md with stronger feature branch workflow requirements

## Test plan
- [x] Build succeeds without errors
- [x] Help output shows updated argument descriptions
- [x] Command accepts file paths for both arguments
- [x] Command still accepts direct text for both arguments
- [x] Version bumped to 2.3.0 for new functionality

🤖 Generated with [Claude Code](https://claude.ai/code)