### PR TITLE
Add oauth command set for ROPC token acquisition and profile management

### DIFF
--- a/Pixelbadger.Toolkit.Tests/OAuthProfileComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/OAuthProfileComponentTests.cs
@@ -1,0 +1,237 @@
+using FluentAssertions;
+using Moq;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Models;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class OAuthProfileComponentTests
+{
+    private readonly Mock<IOAuthProfileService> _mockProfileService;
+    private readonly OAuthProfileComponent _component;
+
+    public OAuthProfileComponentTests()
+    {
+        _mockProfileService = new Mock<IOAuthProfileService>();
+        _component = new OAuthProfileComponent(_mockProfileService.Object);
+    }
+
+    [Fact]
+    public async Task AddProfileAsync_ShouldSaveNewProfile_WhenNameIsUnique()
+    {
+        // Arrange
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync([]);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.AddProfileAsync("dev", "https://auth.example.com", "client-id", "secret", "api://res/.default");
+
+        // Assert
+        savedProfiles.Should().HaveCount(1);
+        savedProfiles![0].Name.Should().Be("dev");
+        savedProfiles[0].AuthorityUri.Should().Be("https://auth.example.com");
+        savedProfiles[0].ClientId.Should().Be("client-id");
+        savedProfiles[0].ClientSecret.Should().Be("secret");
+        savedProfiles[0].Scope.Should().Be("api://res/.default");
+    }
+
+    [Fact]
+    public async Task AddProfileAsync_ShouldSaveProfileWithNullScope_WhenScopeIsNull()
+    {
+        // Arrange
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync([]);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.AddProfileAsync("dev", "https://auth.example.com", "client-id", "secret", null);
+
+        // Assert
+        savedProfiles![0].Scope.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddProfileAsync_ShouldThrow_WhenNameAlreadyExists()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        // Act
+        var act = async () => await _component.AddProfileAsync("dev", "https://other.com", "id2", "s2", null);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'dev'*already exists*");
+    }
+
+    [Fact]
+    public async Task AddProfileAsync_ShouldBeCaseInsensitive_WhenCheckingForDuplicates()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "Dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        // Act
+        var act = async () => await _component.AddProfileAsync("dev", "https://other.com", "id2", "s2", null);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_ShouldUpdateOnlyProvidedFields()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "dev", AuthorityUri = "https://old.example.com", ClientId = "old-id", ClientSecret = "old-secret", Scope = "old-scope" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.UpdateProfileAsync("dev", "https://new.example.com", null, null, null);
+
+        // Assert
+        savedProfiles![0].AuthorityUri.Should().Be("https://new.example.com");
+        savedProfiles[0].ClientId.Should().Be("old-id");
+        savedProfiles[0].ClientSecret.Should().Be("old-secret");
+        savedProfiles[0].Scope.Should().Be("old-scope");
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_ShouldUpdateAllFields_WhenAllProvided()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "dev", AuthorityUri = "https://old.example.com", ClientId = "old-id", ClientSecret = "old-secret", Scope = "old-scope" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.UpdateProfileAsync("dev", "https://new.example.com", "new-id", "new-secret", "new-scope");
+
+        // Assert
+        savedProfiles![0].AuthorityUri.Should().Be("https://new.example.com");
+        savedProfiles[0].ClientId.Should().Be("new-id");
+        savedProfiles[0].ClientSecret.Should().Be("new-secret");
+        savedProfiles[0].Scope.Should().Be("new-scope");
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_ShouldThrow_WhenProfileNotFound()
+    {
+        // Arrange
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync([]);
+
+        // Act
+        var act = async () => await _component.UpdateProfileAsync("missing", null, null, null, null);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'missing'*not found*");
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_ShouldBeCaseInsensitive_WhenFindingProfile()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "Dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret", Scope = null }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>())).Returns(Task.CompletedTask);
+
+        // Act
+        var act = async () => await _component.UpdateProfileAsync("dev", "https://new.example.com", null, null, null);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DeleteProfileAsync_ShouldRemoveProfile_WhenItExists()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret" },
+            new() { Name = "prod", AuthorityUri = "https://prod.example.com", ClientId = "id2", ClientSecret = "secret2" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.DeleteProfileAsync("dev");
+
+        // Assert
+        savedProfiles.Should().HaveCount(1);
+        savedProfiles![0].Name.Should().Be("prod");
+    }
+
+    [Fact]
+    public async Task DeleteProfileAsync_ShouldThrow_WhenProfileNotFound()
+    {
+        // Arrange
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync([]);
+
+        // Act
+        var act = async () => await _component.DeleteProfileAsync("missing");
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'missing'*not found*");
+    }
+
+    [Fact]
+    public async Task DeleteProfileAsync_ShouldBeCaseInsensitive_WhenFindingProfile()
+    {
+        // Arrange
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "Dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        List<OAuthProfile>? savedProfiles = null;
+        _mockProfileService.Setup(x => x.SaveProfilesAsync(It.IsAny<List<OAuthProfile>>()))
+            .Callback<List<OAuthProfile>>(p => savedProfiles = p)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _component.DeleteProfileAsync("dev");
+
+        // Assert
+        savedProfiles.Should().BeEmpty();
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/OAuthTokenComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/OAuthTokenComponentTests.cs
@@ -1,0 +1,238 @@
+using FluentAssertions;
+using Moq;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Models;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class OAuthTokenComponentTests
+{
+    private readonly Mock<IOAuthProfileService> _mockProfileService;
+    private readonly Mock<IOAuthHttpClient> _mockHttpClient;
+    private readonly OAuthTokenComponent _component;
+
+    public OAuthTokenComponentTests()
+    {
+        _mockProfileService = new Mock<IOAuthProfileService>();
+        _mockHttpClient = new Mock<IOAuthHttpClient>();
+        _component = new OAuthTokenComponent(_mockProfileService.Object, _mockHttpClient.Object);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnAccessToken_WhenProfileExistsAndRequestSucceeds()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "my-client-id",
+            ClientSecret = "my-secret",
+            Scope = "api://my-api/.default"
+        };
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync("https://auth.example.com"))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(
+                "https://auth.example.com/token",
+                It.IsAny<Dictionary<string, string>>()))
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "eyJaccess_token" });
+
+        // Act
+        var result = await _component.GetTokenAsync("dev", "user@example.com", "password123");
+
+        // Assert
+        result.Should().Be("eyJaccess_token");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldThrow_WhenProfileNotFound()
+    {
+        // Arrange
+        _mockProfileService.Setup(x => x.GetProfileAsync("missing")).ReturnsAsync((OAuthProfile?)null);
+
+        // Act
+        var act = async () => await _component.GetTokenAsync("missing", "user", "pass");
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*'missing'*not found*");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldIncludeClientSecret_WhenProfileHasOne()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = "secret",
+            Scope = null
+        };
+
+        Dictionary<string, string>? capturedParams = null;
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .Callback<string, Dictionary<string, string>>((_, p) => capturedParams = p)
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "token" });
+
+        // Act
+        await _component.GetTokenAsync("dev", "user", "pass");
+
+        // Assert
+        capturedParams.Should().ContainKey("client_secret").WhoseValue.Should().Be("secret");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldNotIncludeClientSecret_WhenProfileHasNone()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = string.Empty,
+            Scope = null
+        };
+
+        Dictionary<string, string>? capturedParams = null;
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .Callback<string, Dictionary<string, string>>((_, p) => capturedParams = p)
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "token" });
+
+        // Act
+        await _component.GetTokenAsync("dev", "user", "pass");
+
+        // Assert
+        capturedParams.Should().NotContainKey("client_secret");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldIncludeScope_WhenProfileHasOne()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = string.Empty,
+            Scope = "api://resource/.default"
+        };
+
+        Dictionary<string, string>? capturedParams = null;
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .Callback<string, Dictionary<string, string>>((_, p) => capturedParams = p)
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "token" });
+
+        // Act
+        await _component.GetTokenAsync("dev", "user", "pass");
+
+        // Assert
+        capturedParams.Should().ContainKey("scope").WhoseValue.Should().Be("api://resource/.default");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldNotIncludeScope_WhenProfileHasNone()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = string.Empty,
+            Scope = null
+        };
+
+        Dictionary<string, string>? capturedParams = null;
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .Callback<string, Dictionary<string, string>>((_, p) => capturedParams = p)
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "token" });
+
+        // Act
+        await _component.GetTokenAsync("dev", "user", "pass");
+
+        // Assert
+        capturedParams.Should().NotContainKey("scope");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldAlwaysIncludeGrantTypePasswordUsernameClientId()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "my-client",
+            ClientSecret = string.Empty,
+            Scope = null
+        };
+
+        Dictionary<string, string>? capturedParams = null;
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .Callback<string, Dictionary<string, string>>((_, p) => capturedParams = p)
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = "token" });
+
+        // Act
+        await _component.GetTokenAsync("dev", "testuser", "testpass");
+
+        // Assert
+        capturedParams.Should().ContainKey("grant_type").WhoseValue.Should().Be("password");
+        capturedParams.Should().ContainKey("username").WhoseValue.Should().Be("testuser");
+        capturedParams.Should().ContainKey("password").WhoseValue.Should().Be("testpass");
+        capturedParams.Should().ContainKey("client_id").WhoseValue.Should().Be("my-client");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldThrow_WhenTokenResponseHasEmptyAccessToken()
+    {
+        // Arrange
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = string.Empty,
+            Scope = null
+        };
+
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()))
+            .ReturnsAsync("https://auth.example.com/token");
+        _mockHttpClient.Setup(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+            .ReturnsAsync(new OAuthTokenResponse { AccessToken = string.Empty });
+
+        // Act
+        var act = async () => await _component.GetTokenAsync("dev", "user", "pass");
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*access token*");
+    }
+}

--- a/Pixelbadger.Toolkit/Commands/OAuthCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/OAuthCommand.cs
@@ -1,0 +1,267 @@
+using System.CommandLine;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Commands;
+
+public static class OAuthCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("oauth", "OAuth utilities for managing profiles and acquiring tokens");
+
+        command.AddCommand(CreateTokenCommand());
+        command.AddCommand(CreateProfileCommand());
+
+        return command;
+    }
+
+    private static Command CreateTokenCommand()
+    {
+        var command = new Command("token", "Acquire an OAuth access token using Resource Owner Password Credentials");
+
+        var profileOption = new Option<string>(
+            aliases: ["--profile"],
+            description: "Name of the OAuth profile to use")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(profileOption);
+
+        command.SetHandler(async (string profile) =>
+        {
+            try
+            {
+                Console.Write("Username: ");
+                var username = Console.ReadLine() ?? string.Empty;
+
+                var password = ReadSecureInput("Password: ");
+
+                var profileService = new OAuthProfileService();
+                var httpClient = new OAuthHttpClient();
+                var tokenComponent = new OAuthTokenComponent(profileService, httpClient);
+                var accessToken = await tokenComponent.GetTokenAsync(profile, username, password);
+
+                Console.WriteLine(accessToken);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, profileOption);
+
+        return command;
+    }
+
+    private static Command CreateProfileCommand()
+    {
+        var command = new Command("profile", "Manage OAuth profiles");
+
+        command.AddCommand(CreateProfileAddCommand());
+        command.AddCommand(CreateProfileUpdateCommand());
+        command.AddCommand(CreateProfileDeleteCommand());
+
+        return command;
+    }
+
+    private static Command CreateProfileAddCommand()
+    {
+        var command = new Command("add", "Add a new OAuth profile");
+
+        var nameOption = new Option<string>(
+            aliases: ["--name"],
+            description: "Profile name")
+        {
+            IsRequired = true
+        };
+
+        var authorityOption = new Option<string>(
+            aliases: ["--authority"],
+            description: "OAuth authority URI (e.g. https://login.microsoftonline.com/tenant)")
+        {
+            IsRequired = true
+        };
+
+        var clientIdOption = new Option<string>(
+            aliases: ["--client-id"],
+            description: "OAuth client ID")
+        {
+            IsRequired = true
+        };
+
+        var clientSecretOption = new Option<string?>(
+            aliases: ["--client-secret"],
+            description: "OAuth client secret (will be prompted securely if omitted)")
+        {
+            IsRequired = false
+        };
+
+        var scopeOption = new Option<string?>(
+            aliases: ["--scope"],
+            description: "OAuth scope (optional)")
+        {
+            IsRequired = false
+        };
+
+        command.AddOption(nameOption);
+        command.AddOption(authorityOption);
+        command.AddOption(clientIdOption);
+        command.AddOption(clientSecretOption);
+        command.AddOption(scopeOption);
+
+        command.SetHandler(async (string name, string authority, string clientId, string? clientSecret, string? scope) =>
+        {
+            try
+            {
+                if (clientSecret is null)
+                    clientSecret = ReadSecureInput("Client Secret (leave blank if none): ");
+
+                var profileService = new OAuthProfileService();
+                var profileComponent = new OAuthProfileComponent(profileService);
+                await profileComponent.AddProfileAsync(name, authority, clientId, clientSecret, scope);
+
+                Console.WriteLine($"Profile '{name}' added successfully.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, nameOption, authorityOption, clientIdOption, clientSecretOption, scopeOption);
+
+        return command;
+    }
+
+    private static Command CreateProfileUpdateCommand()
+    {
+        var command = new Command("update", "Update an existing OAuth profile");
+
+        var nameOption = new Option<string>(
+            aliases: ["--name"],
+            description: "Profile name to update")
+        {
+            IsRequired = true
+        };
+
+        var authorityOption = new Option<string?>(
+            aliases: ["--authority"],
+            description: "New OAuth authority URI")
+        {
+            IsRequired = false
+        };
+
+        var clientIdOption = new Option<string?>(
+            aliases: ["--client-id"],
+            description: "New OAuth client ID")
+        {
+            IsRequired = false
+        };
+
+        var clientSecretOption = new Option<string?>(
+            aliases: ["--client-secret"],
+            description: "New OAuth client secret (will be prompted securely if omitted)")
+        {
+            IsRequired = false
+        };
+
+        var scopeOption = new Option<string?>(
+            aliases: ["--scope"],
+            description: "New OAuth scope")
+        {
+            IsRequired = false
+        };
+
+        command.AddOption(nameOption);
+        command.AddOption(authorityOption);
+        command.AddOption(clientIdOption);
+        command.AddOption(clientSecretOption);
+        command.AddOption(scopeOption);
+
+        command.SetHandler(async (string name, string? authority, string? clientId, string? clientSecret, string? scope) =>
+        {
+            try
+            {
+                var profileService = new OAuthProfileService();
+                var profileComponent = new OAuthProfileComponent(profileService);
+                await profileComponent.UpdateProfileAsync(name, authority, clientId, clientSecret, scope);
+
+                Console.WriteLine($"Profile '{name}' updated successfully.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, nameOption, authorityOption, clientIdOption, clientSecretOption, scopeOption);
+
+        return command;
+    }
+
+    private static Command CreateProfileDeleteCommand()
+    {
+        var command = new Command("delete", "Delete an OAuth profile");
+
+        var nameOption = new Option<string>(
+            aliases: ["--name"],
+            description: "Profile name to delete")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(nameOption);
+
+        command.SetHandler(async (string name) =>
+        {
+            try
+            {
+                var profileService = new OAuthProfileService();
+                var profileComponent = new OAuthProfileComponent(profileService);
+                await profileComponent.DeleteProfileAsync(name);
+
+                Console.WriteLine($"Profile '{name}' deleted successfully.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, nameOption);
+
+        return command;
+    }
+
+    private static string ReadSecureInput(string prompt)
+    {
+        Console.Write(prompt);
+
+        var input = new System.Text.StringBuilder();
+
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+
+            if (key.Key == ConsoleKey.Enter)
+            {
+                Console.WriteLine();
+                break;
+            }
+
+            if (key.Key == ConsoleKey.Backspace)
+            {
+                if (input.Length > 0)
+                {
+                    input.Remove(input.Length - 1, 1);
+                    Console.Write("\b \b");
+                }
+                continue;
+            }
+
+            input.Append(key.KeyChar);
+            Console.Write('*');
+        }
+
+        return input.ToString();
+    }
+}

--- a/Pixelbadger.Toolkit/Components/OAuthProfileComponent.cs
+++ b/Pixelbadger.Toolkit/Components/OAuthProfileComponent.cs
@@ -1,0 +1,50 @@
+using Pixelbadger.Toolkit.Models;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Components;
+
+public class OAuthProfileComponent(IOAuthProfileService profileService)
+{
+    public async Task AddProfileAsync(string name, string authorityUri, string clientId, string clientSecret, string? scope)
+    {
+        var profiles = await profileService.LoadProfilesAsync();
+
+        if (profiles.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Profile '{name}' already exists.");
+
+        profiles.Add(new OAuthProfile
+        {
+            Name = name,
+            AuthorityUri = authorityUri,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            Scope = scope
+        });
+
+        await profileService.SaveProfilesAsync(profiles);
+    }
+
+    public async Task UpdateProfileAsync(string name, string? authorityUri, string? clientId, string? clientSecret, string? scope)
+    {
+        var profiles = await profileService.LoadProfilesAsync();
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"Profile '{name}' not found.");
+
+        if (authorityUri is not null) profile.AuthorityUri = authorityUri;
+        if (clientId is not null) profile.ClientId = clientId;
+        if (clientSecret is not null) profile.ClientSecret = clientSecret;
+        if (scope is not null) profile.Scope = scope;
+
+        await profileService.SaveProfilesAsync(profiles);
+    }
+
+    public async Task DeleteProfileAsync(string name)
+    {
+        var profiles = await profileService.LoadProfilesAsync();
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"Profile '{name}' not found.");
+
+        profiles.Remove(profile);
+        await profileService.SaveProfilesAsync(profiles);
+    }
+}

--- a/Pixelbadger.Toolkit/Components/OAuthTokenComponent.cs
+++ b/Pixelbadger.Toolkit/Components/OAuthTokenComponent.cs
@@ -1,0 +1,35 @@
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Components;
+
+public class OAuthTokenComponent(IOAuthProfileService profileService, IOAuthHttpClient httpClient)
+{
+    public async Task<string> GetTokenAsync(string profileName, string username, string password)
+    {
+        var profile = await profileService.GetProfileAsync(profileName)
+            ?? throw new InvalidOperationException($"Profile '{profileName}' not found.");
+
+        var tokenEndpoint = await httpClient.DiscoverTokenEndpointAsync(profile.AuthorityUri);
+
+        var parameters = new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = username,
+            ["password"] = password,
+            ["client_id"] = profile.ClientId
+        };
+
+        if (!string.IsNullOrEmpty(profile.ClientSecret))
+            parameters["client_secret"] = profile.ClientSecret;
+
+        if (!string.IsNullOrEmpty(profile.Scope))
+            parameters["scope"] = profile.Scope;
+
+        var tokenResponse = await httpClient.RequestTokenAsync(tokenEndpoint, parameters);
+
+        if (string.IsNullOrEmpty(tokenResponse.AccessToken))
+            throw new InvalidOperationException("Token response did not contain an access token.");
+
+        return tokenResponse.AccessToken;
+    }
+}

--- a/Pixelbadger.Toolkit/Models/OAuthProfile.cs
+++ b/Pixelbadger.Toolkit/Models/OAuthProfile.cs
@@ -1,0 +1,10 @@
+namespace Pixelbadger.Toolkit.Models;
+
+public class OAuthProfile
+{
+    public string Name { get; set; } = string.Empty;
+    public string AuthorityUri { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+    public string? Scope { get; set; }
+}

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;openai</PackageTags>

--- a/Pixelbadger.Toolkit/Program.cs
+++ b/Pixelbadger.Toolkit/Program.cs
@@ -8,5 +8,6 @@ rootCommand.AddCommand(InterpretersCommand.Create());
 rootCommand.AddCommand(ImagesCommand.Create());
 rootCommand.AddCommand(WebCommand.Create());
 rootCommand.AddCommand(OpenAiCommand.Create());
+rootCommand.AddCommand(OAuthCommand.Create());
 
 return await rootCommand.InvokeAsync(args);

--- a/Pixelbadger.Toolkit/Services/IOAuthHttpClient.cs
+++ b/Pixelbadger.Toolkit/Services/IOAuthHttpClient.cs
@@ -1,0 +1,14 @@
+namespace Pixelbadger.Toolkit.Services;
+
+public interface IOAuthHttpClient
+{
+    Task<string> DiscoverTokenEndpointAsync(string authorityUri);
+    Task<OAuthTokenResponse> RequestTokenAsync(string tokenEndpoint, Dictionary<string, string> parameters);
+}
+
+public class OAuthTokenResponse
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string? TokenType { get; set; }
+    public int? ExpiresIn { get; set; }
+}

--- a/Pixelbadger.Toolkit/Services/IOAuthProfileService.cs
+++ b/Pixelbadger.Toolkit/Services/IOAuthProfileService.cs
@@ -1,0 +1,11 @@
+using Pixelbadger.Toolkit.Models;
+
+namespace Pixelbadger.Toolkit.Services;
+
+public interface IOAuthProfileService
+{
+    Task<List<OAuthProfile>> LoadProfilesAsync();
+    Task SaveProfilesAsync(List<OAuthProfile> profiles);
+    Task<OAuthProfile?> GetProfileAsync(string name);
+    string ProfilesFilePath { get; }
+}

--- a/Pixelbadger.Toolkit/Services/OAuthHttpClient.cs
+++ b/Pixelbadger.Toolkit/Services/OAuthHttpClient.cs
@@ -1,0 +1,55 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Pixelbadger.Toolkit.Services;
+
+public class OAuthHttpClient : IOAuthHttpClient
+{
+    private readonly HttpClient _httpClient = new();
+
+    public async Task<string> DiscoverTokenEndpointAsync(string authorityUri)
+    {
+        var discoveryUrl = $"{authorityUri.TrimEnd('/')}/.well-known/openid-configuration";
+        var response = await _httpClient.GetAsync(discoveryUrl);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        var document = JsonDocument.Parse(json);
+
+        if (!document.RootElement.TryGetProperty("token_endpoint", out var tokenEndpointElement))
+            throw new InvalidOperationException($"OIDC discovery document from '{discoveryUrl}' does not contain 'token_endpoint'.");
+
+        return tokenEndpointElement.GetString()
+            ?? throw new InvalidOperationException("'token_endpoint' in OIDC discovery document is null.");
+    }
+
+    public async Task<OAuthTokenResponse> RequestTokenAsync(string tokenEndpoint, Dictionary<string, string> parameters)
+    {
+        var content = new FormUrlEncodedContent(parameters);
+        var response = await _httpClient.PostAsync(tokenEndpoint, content);
+        response.EnsureSuccessStatusCode();
+
+        var tokenResponse = await response.Content.ReadFromJsonAsync<OAuthTokenResponseJson>()
+            ?? throw new InvalidOperationException("Failed to deserialize token response.");
+
+        return new OAuthTokenResponse
+        {
+            AccessToken = tokenResponse.AccessToken ?? string.Empty,
+            TokenType = tokenResponse.TokenType,
+            ExpiresIn = tokenResponse.ExpiresIn
+        };
+    }
+
+    private sealed class OAuthTokenResponseJson
+    {
+        [JsonPropertyName("access_token")]
+        public string? AccessToken { get; set; }
+
+        [JsonPropertyName("token_type")]
+        public string? TokenType { get; set; }
+
+        [JsonPropertyName("expires_in")]
+        public int? ExpiresIn { get; set; }
+    }
+}

--- a/Pixelbadger.Toolkit/Services/OAuthProfileService.cs
+++ b/Pixelbadger.Toolkit/Services/OAuthProfileService.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Pixelbadger.Toolkit.Models;
+
+namespace Pixelbadger.Toolkit.Services;
+
+public class OAuthProfileService : IOAuthProfileService
+{
+    public string ProfilesFilePath { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".pbtk",
+        "oauth-profiles.json");
+
+    public async Task<List<OAuthProfile>> LoadProfilesAsync()
+    {
+        if (!File.Exists(ProfilesFilePath))
+            return [];
+
+        var json = await File.ReadAllTextAsync(ProfilesFilePath);
+        return JsonSerializer.Deserialize<List<OAuthProfile>>(json) ?? [];
+    }
+
+    public async Task SaveProfilesAsync(List<OAuthProfile> profiles)
+    {
+        var directory = Path.GetDirectoryName(ProfilesFilePath)!;
+        Directory.CreateDirectory(directory);
+
+        var json = JsonSerializer.Serialize(profiles, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(ProfilesFilePath, json);
+    }
+
+    public async Task<OAuthProfile?> GetProfileAsync(string name)
+    {
+        var profiles = await LoadProfilesAsync();
+        return profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `oauth token --profile <name>` — prompts for username (visible) and password (masked), discovers the token endpoint via OIDC, POSTs an ROPC grant, and prints the access token
- Adds `oauth profile add/update/delete` — manages named OAuth profiles persisted to `~/.pbtk/oauth-profiles.json`
- Bumps version `3.0.0` → `3.1.0` (minor: new feature)

## Test plan

- [ ] `dotnet build` passes with no warnings
- [ ] `dotnet test` passes (240/240 tests, including 18 new tests across `OAuthTokenComponentTests` and `OAuthProfileComponentTests`)
- [ ] `oauth profile add --name dev --authority <uri> --client-id <id>` creates a profile in `~/.pbtk/oauth-profiles.json`
- [ ] `oauth profile update --name dev --authority <new-uri>` updates only the authority field
- [ ] `oauth profile delete --name dev` removes the profile
- [ ] `oauth token --profile dev` prompts for username and masked password, then prints an access token

🤖 Generated with [Claude Code](https://claude.com/claude-code)