### PR TITLE
Add homomorphic encryption command set (Paillier cryptosystem)

### DIFF
--- a/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics;
+using FluentAssertions;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class CryptoCommandIntegrationTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public CryptoCommandIntegrationTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+            Directory.Delete(_testDirectory, true);
+    }
+
+    [Fact]
+    public async Task GenerateKey_ShouldCreateKeyFile_WhenKeyFileOptionProvided()
+    {
+        var keyFile = Path.Combine(_testDirectory, "test.key");
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "generate-key", "--key-file", keyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Should().Contain("Key pair written to");
+        File.Exists(keyFile).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Encrypt_ShouldCreateEncryptedFile_WhenValidOptionsProvided()
+    {
+        var keyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "number.enc");
+
+        await RunToolkitCommandAsync("crypto", "generate-key", "--key-file", keyFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "encrypt", "--number", "42", "--key-file", keyFile, "--out-file", encFile);
+
+        exitCode.Should().Be(0);
+        stdout.Should().Contain("Encrypted number written to");
+        File.Exists(encFile).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Decrypt_ShouldReturnOriginalPlaintext_WhenDecryptingEncryptedNumber()
+    {
+        var keyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "number.enc");
+
+        await RunToolkitCommandAsync("crypto", "generate-key", "--key-file", keyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt", "--number", "99", "--key-file", keyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", encFile, "--key-file", keyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("99");
+    }
+
+    [Fact]
+    public async Task Add_ShouldProduceEncryptedSumThatDecryptsToCorrectValue()
+    {
+        var keyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile1 = Path.Combine(_testDirectory, "a.enc");
+        var encFile2 = Path.Combine(_testDirectory, "b.enc");
+        var sumFile = Path.Combine(_testDirectory, "sum.enc");
+
+        await RunToolkitCommandAsync("crypto", "generate-key", "--key-file", keyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt", "--number", "37", "--key-file", keyFile, "--out-file", encFile1);
+        await RunToolkitCommandAsync("crypto", "encrypt", "--number", "5", "--key-file", keyFile, "--out-file", encFile2);
+        await RunToolkitCommandAsync("crypto", "add", "--in-file1", encFile1, "--in-file2", encFile2, "--out-file", sumFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", sumFile, "--key-file", keyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("42");
+    }
+
+    [Fact]
+    public async Task GenerateKey_ShouldReturnFailure_WhenKeyFileOptionIsMissing()
+    {
+        var (exitCode, stdout, stderr) = await RunToolkitCommandAsync("crypto", "generate-key");
+
+        exitCode.Should().NotBe(0);
+        (stdout + stderr).Should().Contain("--key-file");
+    }
+
+    [Fact]
+    public async Task Encrypt_ShouldReturnFailure_WhenKeyFileDoesNotExist()
+    {
+        var missingKeyFile = Path.Combine(_testDirectory, "missing.key");
+        var encFile = Path.Combine(_testDirectory, "number.enc");
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "encrypt", "--number", "42", "--key-file", missingKeyFile, "--out-file", encFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Decrypt_ShouldReturnFailure_WhenKeyFileContainsMalformedJson()
+    {
+        var keyFile = Path.Combine(_testDirectory, "bad.key");
+        var encFile = Path.Combine(_testDirectory, "number.enc");
+
+        await File.WriteAllTextAsync(keyFile, "{ not valid json }");
+        await File.WriteAllTextAsync(encFile, "{ \"Ciphertext\": \"12345\", \"N\": \"99999\" }");
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", encFile, "--key-file", keyFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Add_ShouldReturnFailure_WhenFirstInputFileDoesNotExist()
+    {
+        var keyFile = Path.Combine(_testDirectory, "test.key");
+        var missingFile = Path.Combine(_testDirectory, "missing.enc");
+        var encFile = Path.Combine(_testDirectory, "number.enc");
+        var sumFile = Path.Combine(_testDirectory, "sum.enc");
+
+        await RunToolkitCommandAsync("crypto", "generate-key", "--key-file", keyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt", "--number", "5", "--key-file", keyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "add", "--in-file1", missingFile, "--in-file2", encFile, "--out-file", sumFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunToolkitCommandAsync(params string[] args)
+    {
+        var projectPath = GetToolkitProjectPath();
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("Debug");
+        startInfo.ArgumentList.Add("--no-build");
+        startInfo.ArgumentList.Add("--");
+
+        foreach (var arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        using var process = Process.Start(startInfo)!;
+        var standardOutput = await process.StandardOutput.ReadToEndAsync();
+        var standardError = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode, standardOutput, standardError);
+    }
+
+    private static string GetToolkitProjectPath() =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "../../../../Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj"));
+}

--- a/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
@@ -1,0 +1,152 @@
+using System.Numerics;
+using FluentAssertions;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Models;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class HomomorphicEncryptionComponentTests
+{
+    // 64-bit keys (32-bit primes) for fast test execution
+    private const int TestKeyBitLength = 64;
+    private readonly HomomorphicEncryptionComponent _component = new();
+
+    [Fact]
+    public void GenerateKey_ShouldReturnKeyPairWithValidPositiveBigIntegerStrings()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        BigInteger.TryParse(key.N, out var n).Should().BeTrue();
+        BigInteger.TryParse(key.Lambda, out var lambda).Should().BeTrue();
+        BigInteger.TryParse(key.Mu, out var mu).Should().BeTrue();
+        n.Should().BeGreaterThan(BigInteger.Zero);
+        lambda.Should().BeGreaterThan(BigInteger.Zero);
+        mu.Should().BeGreaterThan(BigInteger.Zero);
+    }
+
+    [Fact]
+    public void GenerateKey_ShouldSatisfyPaillierKeyRelationship_MuIsModularInverseOfLambdaModN()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+        var n = BigInteger.Parse(key.N);
+        var lambda = BigInteger.Parse(key.Lambda);
+        var mu = BigInteger.Parse(key.Mu);
+
+        // mu = lambda^-1 mod n, so lambda * mu ≡ 1 mod n
+        (lambda * mu % n).Should().Be(BigInteger.One);
+    }
+
+    [Fact]
+    public void Encrypt_ShouldReturnCiphertextDifferentFromPlaintext()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encrypted = _component.Encrypt(42L, key);
+
+        BigInteger.TryParse(encrypted.Ciphertext, out var ciphertext).Should().BeTrue();
+        ciphertext.Should().NotBe(new BigInteger(42));
+        encrypted.N.Should().Be(key.N);
+    }
+
+    [Fact]
+    public void Encrypt_ShouldProduceProbabilisticCiphertext_SamePlaintextYieldsDifferentCiphertexts()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encrypted1 = _component.Encrypt(7L, key);
+        var encrypted2 = _component.Encrypt(7L, key);
+
+        // Paillier is semantically secure: same plaintext encrypts to different ciphertexts
+        encrypted1.Ciphertext.Should().NotBe(encrypted2.Ciphertext);
+    }
+
+    [Fact]
+    public void Decrypt_ShouldReturnOriginalPlaintext_WhenDecryptingEncryptedNumber()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encrypted = _component.Encrypt(42L, key);
+        var decrypted = _component.Decrypt(encrypted, key);
+
+        decrypted.Should().Be(new BigInteger(42));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(100L)]
+    [InlineData(999999L)]
+    public void Decrypt_ShouldReturnCorrectValue_ForVariousPlaintextValues(long plaintext)
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encrypted = _component.Encrypt(plaintext, key);
+        var decrypted = _component.Decrypt(encrypted, key);
+
+        decrypted.Should().Be(new BigInteger(plaintext));
+    }
+
+    [Fact]
+    public void AddEncrypted_ShouldDecryptToSumOfOriginalValues()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encryptedA = _component.Encrypt(15L, key);
+        var encryptedB = _component.Encrypt(27L, key);
+        var encryptedSum = _component.AddEncrypted(encryptedA, encryptedB);
+        var decryptedSum = _component.Decrypt(encryptedSum, key);
+
+        decryptedSum.Should().Be(new BigInteger(42));
+    }
+
+    [Fact]
+    public void AddEncrypted_ShouldDecryptToCorrectSum_WhenAddingZero()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encryptedA = _component.Encrypt(99L, key);
+        var encryptedZero = _component.Encrypt(0L, key);
+        var encryptedSum = _component.AddEncrypted(encryptedA, encryptedZero);
+        var decryptedSum = _component.Decrypt(encryptedSum, key);
+
+        decryptedSum.Should().Be(new BigInteger(99));
+    }
+
+    [Fact]
+    public void AddEncrypted_ShouldReturnEncryptedNumberWithSameN_AsInputs()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var encryptedA = _component.Encrypt(5L, key);
+        var encryptedB = _component.Encrypt(3L, key);
+        var encryptedSum = _component.AddEncrypted(encryptedA, encryptedB);
+
+        encryptedSum.N.Should().Be(key.N);
+    }
+
+    [Fact]
+    public void Encrypt_ShouldThrowArgumentException_WhenPlaintextIsNegative()
+    {
+        var key = _component.GenerateKey(TestKeyBitLength);
+
+        var act = () => _component.Encrypt(-1L, key);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*non-negative*");
+    }
+
+    [Fact]
+    public void AddEncrypted_ShouldThrowArgumentException_WhenPublicKeysDoNotMatch()
+    {
+        var key1 = _component.GenerateKey(TestKeyBitLength);
+        var key2 = _component.GenerateKey(TestKeyBitLength);
+
+        var encrypted1 = _component.Encrypt(5L, key1);
+        var encrypted2 = _component.Encrypt(3L, key2);
+
+        var act = () => _component.AddEncrypted(encrypted1, encrypted2);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*same public key*");
+    }
+}

--- a/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
@@ -1,0 +1,215 @@
+using System.CommandLine;
+using System.Text.Json;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Models;
+
+namespace Pixelbadger.Toolkit.Commands;
+
+public static class CryptoCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public static Command Create()
+    {
+        var command = new Command("crypto", "Homomorphic encryption utilities using the Paillier cryptosystem");
+
+        command.AddCommand(CreateGenerateKeyCommand());
+        command.AddCommand(CreateEncryptCommand());
+        command.AddCommand(CreateDecryptCommand());
+        command.AddCommand(CreateAddCommand());
+
+        return command;
+    }
+
+    private static Command CreateGenerateKeyCommand()
+    {
+        var command = new Command("generate-key", "Generate a Paillier key pair and save it to a file");
+
+        var keyFileOption = new Option<string>(
+            aliases: ["--key-file"],
+            description: "Path to write the generated key pair JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(keyFileOption);
+
+        command.SetHandler(async (string keyFile) =>
+        {
+            try
+            {
+                var component = new HomomorphicEncryptionComponent();
+                var keyPair = component.GenerateKey();
+                var json = JsonSerializer.Serialize(keyPair, JsonOptions);
+                await File.WriteAllTextAsync(keyFile, json);
+                Console.WriteLine($"Key pair written to '{keyFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, keyFileOption);
+
+        return command;
+    }
+
+    private static Command CreateEncryptCommand()
+    {
+        var command = new Command("encrypt", "Encrypt a number using a Paillier public key");
+
+        var numberOption = new Option<long>(
+            aliases: ["--number"],
+            description: "The non-negative integer to encrypt")
+        {
+            IsRequired = true
+        };
+
+        var keyFileOption = new Option<string>(
+            aliases: ["--key-file"],
+            description: "Path to the key pair JSON file")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted number JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(numberOption);
+        command.AddOption(keyFileOption);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (long number, string keyFile, string outFile) =>
+        {
+            try
+            {
+                var keyJson = await File.ReadAllTextAsync(keyFile);
+                var keyPair = JsonSerializer.Deserialize<PaillierKeyPair>(keyJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize key pair.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var encrypted = component.Encrypt(number, keyPair);
+
+                var json = JsonSerializer.Serialize(encrypted, JsonOptions);
+                await File.WriteAllTextAsync(outFile, json);
+                Console.WriteLine($"Encrypted number written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, numberOption, keyFileOption, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateDecryptCommand()
+    {
+        var command = new Command("decrypt", "Decrypt an encrypted number using a Paillier private key");
+
+        var inFileOption = new Option<string>(
+            aliases: ["--in-file"],
+            description: "Path to the encrypted number JSON file")
+        {
+            IsRequired = true
+        };
+
+        var keyFileOption = new Option<string>(
+            aliases: ["--key-file"],
+            description: "Path to the key pair JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFileOption);
+        command.AddOption(keyFileOption);
+
+        command.SetHandler(async (string inFile, string keyFile) =>
+        {
+            try
+            {
+                var encryptedJson = await File.ReadAllTextAsync(inFile);
+                var encrypted = JsonSerializer.Deserialize<EncryptedNumber>(encryptedJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize encrypted number.");
+
+                var keyJson = await File.ReadAllTextAsync(keyFile);
+                var keyPair = JsonSerializer.Deserialize<PaillierKeyPair>(keyJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize key pair.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var plaintext = component.Decrypt(encrypted, keyPair);
+                Console.WriteLine(plaintext.ToString());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFileOption, keyFileOption);
+
+        return command;
+    }
+
+    private static Command CreateAddCommand()
+    {
+        var command = new Command("add", "Homomorphically add two encrypted numbers without decrypting them");
+
+        var inFile1Option = new Option<string>(
+            aliases: ["--in-file1"],
+            description: "Path to the first encrypted number JSON file")
+        {
+            IsRequired = true
+        };
+
+        var inFile2Option = new Option<string>(
+            aliases: ["--in-file2"],
+            description: "Path to the second encrypted number JSON file")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted sum JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFile1Option);
+        command.AddOption(inFile2Option);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string inFile1, string inFile2, string outFile) =>
+        {
+            try
+            {
+                var enc1Json = await File.ReadAllTextAsync(inFile1);
+                var encrypted1 = JsonSerializer.Deserialize<EncryptedNumber>(enc1Json)
+                    ?? throw new InvalidOperationException("Failed to deserialize first encrypted number.");
+
+                var enc2Json = await File.ReadAllTextAsync(inFile2);
+                var encrypted2 = JsonSerializer.Deserialize<EncryptedNumber>(enc2Json)
+                    ?? throw new InvalidOperationException("Failed to deserialize second encrypted number.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var sum = component.AddEncrypted(encrypted1, encrypted2);
+
+                var json = JsonSerializer.Serialize(sum, JsonOptions);
+                await File.WriteAllTextAsync(outFile, json);
+                Console.WriteLine($"Encrypted sum written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFile1Option, inFile2Option, outFileOption);
+
+        return command;
+    }
+}

--- a/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
+++ b/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
@@ -1,0 +1,183 @@
+using System.Numerics;
+using System.Security.Cryptography;
+using Pixelbadger.Toolkit.Models;
+
+namespace Pixelbadger.Toolkit.Components;
+
+public class HomomorphicEncryptionComponent
+{
+    public PaillierKeyPair GenerateKey(int bitLength = 512)
+    {
+        using var rng = RandomNumberGenerator.Create();
+        BigInteger p, q;
+        do
+        {
+            p = GeneratePrime(bitLength / 2, rng);
+            q = GeneratePrime(bitLength / 2, rng);
+        } while (p == q);
+
+        var n = p * q;
+        var lambda = Lcm(p - 1, q - 1);
+        var mu = ModInverse(lambda, n);
+
+        return new PaillierKeyPair
+        {
+            N = n.ToString(),
+            Lambda = lambda.ToString(),
+            Mu = mu.ToString()
+        };
+    }
+
+    public EncryptedNumber Encrypt(long plaintext, PaillierKeyPair key)
+    {
+        if (plaintext < 0)
+            throw new ArgumentException("Plaintext must be non-negative.", nameof(plaintext));
+
+        var n = BigInteger.Parse(key.N);
+        var m = new BigInteger(plaintext);
+
+        if (m >= n)
+            throw new ArgumentException("Plaintext must be less than n.", nameof(plaintext));
+
+        var nSquared = n * n;
+        var g = n + 1;
+
+        using var rng = RandomNumberGenerator.Create();
+        BigInteger r;
+        do
+        {
+            r = GenerateRandomBigInteger(n, rng);
+        } while (BigInteger.GreatestCommonDivisor(r, n) != 1);
+
+        var ciphertext = BigInteger.ModPow(g, m, nSquared) * BigInteger.ModPow(r, n, nSquared) % nSquared;
+
+        return new EncryptedNumber
+        {
+            Ciphertext = ciphertext.ToString(),
+            N = key.N
+        };
+    }
+
+    public BigInteger Decrypt(EncryptedNumber encryptedNumber, PaillierKeyPair key)
+    {
+        var n = BigInteger.Parse(key.N);
+        var lambda = BigInteger.Parse(key.Lambda);
+        var mu = BigInteger.Parse(key.Mu);
+        var c = BigInteger.Parse(encryptedNumber.Ciphertext);
+        var nSquared = n * n;
+
+        var x = BigInteger.ModPow(c, lambda, nSquared);
+        return L(x, n) * mu % n;
+    }
+
+    public EncryptedNumber AddEncrypted(EncryptedNumber a, EncryptedNumber b)
+    {
+        if (a.N != b.N)
+            throw new ArgumentException("Both encrypted numbers must use the same public key (N).");
+
+        var n = BigInteger.Parse(a.N);
+        var nSquared = n * n;
+        var c1 = BigInteger.Parse(a.Ciphertext);
+        var c2 = BigInteger.Parse(b.Ciphertext);
+
+        return new EncryptedNumber
+        {
+            Ciphertext = (c1 * c2 % nSquared).ToString(),
+            N = a.N
+        };
+    }
+
+    private static BigInteger L(BigInteger x, BigInteger n) => (x - 1) / n;
+
+    private static BigInteger Lcm(BigInteger a, BigInteger b) =>
+        a / BigInteger.GreatestCommonDivisor(a, b) * b;
+
+    private static BigInteger ModInverse(BigInteger a, BigInteger m)
+    {
+        var (gcd, x, _) = ExtendedGcd(((a % m) + m) % m, m);
+        if (gcd != 1)
+            throw new InvalidOperationException("Modular inverse does not exist.");
+        return (x % m + m) % m;
+    }
+
+    private static (BigInteger Gcd, BigInteger X, BigInteger Y) ExtendedGcd(BigInteger a, BigInteger b)
+    {
+        if (a == 0) return (b, BigInteger.Zero, BigInteger.One);
+        var (g, x, y) = ExtendedGcd(b % a, a);
+        return (g, y - b / a * x, x);
+    }
+
+    private static BigInteger GeneratePrime(int bitLength, RandomNumberGenerator rng)
+    {
+        var byteCount = bitLength / 8;
+        var bytes = new byte[byteCount];
+        while (true)
+        {
+            rng.GetBytes(bytes);
+            bytes[^1] |= 0x80; // Ensure MSB set so candidate has exactly bitLength bits
+            bytes[0] |= 0x01;  // Ensure odd
+            var candidate = new BigInteger(bytes, isUnsigned: true);
+            if (IsProbablePrime(candidate, 20, rng))
+                return candidate;
+        }
+    }
+
+    private static bool IsProbablePrime(BigInteger n, int witnesses, RandomNumberGenerator rng)
+    {
+        if (n < 2) return false;
+        if (n == 2 || n == 3) return true;
+        if (n.IsEven) return false;
+
+        var d = n - 1;
+        var r = 0;
+        while (d.IsEven)
+        {
+            d >>= 1;
+            r++;
+        }
+
+        var byteCount = n.GetByteCount(isUnsigned: true);
+        var bytes = new byte[byteCount];
+
+        for (var i = 0; i < witnesses; i++)
+        {
+            BigInteger a;
+            do
+            {
+                rng.GetBytes(bytes);
+                a = new BigInteger(bytes, isUnsigned: true) % n;
+            } while (a < 2 || a >= n - 2);
+
+            var x = BigInteger.ModPow(a, d, n);
+            if (x == 1 || x == n - 1) continue;
+
+            var composite = true;
+            for (var j = 0; j < r - 1; j++)
+            {
+                x = BigInteger.ModPow(x, 2, n);
+                if (x == n - 1)
+                {
+                    composite = false;
+                    break;
+                }
+            }
+
+            if (composite) return false;
+        }
+
+        return true;
+    }
+
+    private static BigInteger GenerateRandomBigInteger(BigInteger max, RandomNumberGenerator rng)
+    {
+        var byteCount = max.GetByteCount(isUnsigned: true);
+        var bytes = new byte[byteCount];
+        BigInteger result;
+        do
+        {
+            rng.GetBytes(bytes);
+            result = new BigInteger(bytes, isUnsigned: true);
+        } while (result <= 0 || result >= max);
+        return result;
+    }
+}

--- a/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
+++ b/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
@@ -94,17 +94,20 @@ public class HomomorphicEncryptionComponent
 
     private static BigInteger ModInverse(BigInteger a, BigInteger m)
     {
-        var (gcd, x, _) = ExtendedGcd(((a % m) + m) % m, m);
-        if (gcd != 1)
-            throw new InvalidOperationException("Modular inverse does not exist.");
-        return (x % m + m) % m;
-    }
+        BigInteger oldR = ((a % m) + m) % m, r = m;
+        BigInteger oldS = BigInteger.One, s = BigInteger.Zero;
 
-    private static (BigInteger Gcd, BigInteger X, BigInteger Y) ExtendedGcd(BigInteger a, BigInteger b)
-    {
-        if (a == 0) return (b, BigInteger.Zero, BigInteger.One);
-        var (g, x, y) = ExtendedGcd(b % a, a);
-        return (g, y - b / a * x, x);
+        while (r != 0)
+        {
+            var q = oldR / r;
+            (oldR, r) = (r, oldR - q * r);
+            (oldS, s) = (s, oldS - q * s);
+        }
+
+        if (oldR != 1)
+            throw new InvalidOperationException("Modular inverse does not exist.");
+
+        return (oldS % m + m) % m;
     }
 
     private static BigInteger GeneratePrime(int bitLength, RandomNumberGenerator rng)

--- a/Pixelbadger.Toolkit/Models/EncryptedNumber.cs
+++ b/Pixelbadger.Toolkit/Models/EncryptedNumber.cs
@@ -1,0 +1,7 @@
+namespace Pixelbadger.Toolkit.Models;
+
+public class EncryptedNumber
+{
+    public string Ciphertext { get; set; } = string.Empty;
+    public string N { get; set; } = string.Empty;
+}

--- a/Pixelbadger.Toolkit/Models/PaillierKeyPair.cs
+++ b/Pixelbadger.Toolkit/Models/PaillierKeyPair.cs
@@ -1,0 +1,8 @@
+namespace Pixelbadger.Toolkit.Models;
+
+public class PaillierKeyPair
+{
+    public string N { get; set; } = string.Empty;
+    public string Lambda { get; set; } = string.Empty;
+    public string Mu { get; set; } = string.Empty;
+}

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;openai</PackageTags>

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -12,8 +12,8 @@
     <PackageId>Pixelbadger.Toolkit</PackageId>
     <Version>3.3.0</Version>
     <Authors>Pixelbadger</Authors>
-    <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.</Description>
-    <PackageTags>cli;toolkit;strings;interpreters;steganography;openai</PackageTags>
+    <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.</Description>
+    <PackageTags>cli;toolkit;strings;interpreters;steganography;openai;crypto;homomorphic-encryption</PackageTags>
     <RepositoryUrl>https://github.com/pixelbadger/Pixelbadger.Toolkit</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Pixelbadger.Toolkit/Program.cs
+++ b/Pixelbadger.Toolkit/Program.cs
@@ -9,5 +9,6 @@ rootCommand.AddCommand(ImagesCommand.Create());
 rootCommand.AddCommand(WebCommand.Create());
 rootCommand.AddCommand(OpenAiCommand.Create());
 rootCommand.AddCommand(OAuthCommand.Create());
+rootCommand.AddCommand(CryptoCommand.Create());
 
 return await rootCommand.InvokeAsync(args);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pixelbadger.Toolkit
 
-A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, and OpenAI integration.
+A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.
 
 > **Note**: Search and MCP RAG functionality has been extracted to the separate [Pixelbadger.Toolkit.Rag](https://github.com/pixelbadger/Pixelbadger.Toolkit.Rag) repository (`pbrag` CLI tool).
 
@@ -26,6 +26,11 @@ A CLI toolkit exposing varied functionality organized by topic, including string
     - [translate](#translate)
     - [ocaaar](#ocaaar)
     - [corpospeak](#corpospeak)
+  - [crypto](#crypto)
+    - [generate-key](#generate-key)
+    - [encrypt](#encrypt)
+    - [decrypt](#decrypt)
+    - [add](#add)
 - [Help](#help)
 - [Requirements](#requirements)
 - [Technical Details](#technical-details)
@@ -415,6 +420,86 @@ pbtk openai corpospeak --source "Database migration finished" --audience "operat
 - **hr**: People impact and organizational dynamics
 - **customer-success**: Customer experience and support focus
 
+### crypto
+Homomorphic encryption utilities using the Paillier cryptosystem. Encrypted numbers can be added together without ever decrypting them — the result decrypts to the correct sum.
+
+> **Security note**: The key file produced by `generate-key` contains both the public components (`N`) and the private components (`Lambda`, `Mu`). Keep this file secret. If you need a third party to encrypt values for you, share only the `N` value from the key file, not the file itself.
+
+#### generate-key
+Generates a Paillier key pair and writes it to a JSON file.
+
+**Usage:**
+```bash
+pbtk crypto generate-key --key-file <key-file>
+```
+
+**Options:**
+- `--key-file`: Path to write the generated key pair JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto generate-key --key-file my.key
+```
+
+#### encrypt
+Encrypts a non-negative integer using the Paillier public key. Paillier encryption is probabilistic — encrypting the same number twice produces different ciphertexts, both of which decrypt to the same value.
+
+**Usage:**
+```bash
+pbtk crypto encrypt --number <number> --key-file <key-file> --out-file <output-file>
+```
+
+**Options:**
+- `--number`: The non-negative integer to encrypt (required)
+- `--key-file`: Path to the key pair JSON file (required)
+- `--out-file`: Path to write the encrypted number JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt --number 37 --key-file my.key --out-file a.enc
+```
+
+#### decrypt
+Decrypts an encrypted number using the Paillier private key and prints the plaintext.
+
+**Usage:**
+```bash
+pbtk crypto decrypt --in-file <encrypted-file> --key-file <key-file>
+```
+
+**Options:**
+- `--in-file`: Path to the encrypted number JSON file (required)
+- `--key-file`: Path to the key pair JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto decrypt --in-file a.enc --key-file my.key
+```
+
+#### add
+Homomorphically adds two encrypted numbers without decrypting them. The resulting file can be decrypted to yield the sum of the two original plaintexts.
+
+**Usage:**
+```bash
+pbtk crypto add --in-file1 <first-encrypted-file> --in-file2 <second-encrypted-file> --out-file <output-file>
+```
+
+**Options:**
+- `--in-file1`: Path to the first encrypted number JSON file (required)
+- `--in-file2`: Path to the second encrypted number JSON file (required)
+- `--out-file`: Path to write the encrypted sum JSON file (required)
+
+**Example:**
+```bash
+# Encrypt 37 and 5, add without decrypting, then reveal the sum
+pbtk crypto generate-key --key-file my.key
+pbtk crypto encrypt --number 37 --key-file my.key --out-file a.enc
+pbtk crypto encrypt --number 5  --key-file my.key --out-file b.enc
+pbtk crypto add --in-file1 a.enc --in-file2 b.enc --out-file sum.enc
+pbtk crypto decrypt --in-file sum.enc --key-file my.key
+# Output: 42
+```
+
 ## Help
 
 Get help for any command by adding `--help`:
@@ -442,3 +527,6 @@ The steganography feature uses LSB (Least Significant Bit) encoding to hide mess
 ### Supported Languages
 - **Brainfuck**: A minimalist esoteric programming language with 8 commands
 - **Ook**: A Brainfuck derivative using "Ook." and "Ook?" syntax inspired by Terry Pratchett's Discworld orangutans
+
+### Homomorphic Encryption Implementation
+The `crypto` topic uses the simplified Paillier cryptosystem, a partially homomorphic encryption scheme supporting additive operations on ciphertexts. Key generation uses Miller-Rabin primality testing (20 witnesses) via `System.Security.Cryptography.RandomNumberGenerator`. All big-integer arithmetic is performed using `System.Numerics.BigInteger` — no third-party cryptography library is required. The default key size is 512 bits; ciphertexts live in Z_{n²} and are therefore approximately 1024 bits in length. The scheme is partially homomorphic: addition of plaintexts corresponds to multiplication of their ciphertexts modulo n².


### PR DESCRIPTION
## Summary

- Adds a new `crypto` topic with four actions: `generate-key`, `encrypt`, `decrypt`, and `add`
- Implements the Paillier partially homomorphic encryption scheme entirely in managed code using `System.Numerics.BigInteger` — no third-party crypto library required
- The `add` action performs additive homomorphic addition on two ciphertexts without decrypting them, demonstrating the core HE property
- Bumps version to 3.3.0

## Usage

```
pbtk crypto generate-key --key-file my.key
pbtk crypto encrypt --number 37 --key-file my.key --out-file a.enc
pbtk crypto encrypt --number 5  --key-file my.key --out-file b.enc
pbtk crypto add --in-file1 a.enc --in-file2 b.enc --out-file sum.enc
pbtk crypto decrypt --in-file sum.enc --key-file my.key   # prints 42
```

## Test plan

- [x] Build succeeds with zero warnings
- [x] 14 unit tests pass covering key generation, encrypt/decrypt round-trips, probabilistic ciphertext, homomorphic addition, zero addition, and error cases
- [x] Full suite (267 tests) passes with no regressions
- [x] Manual end-to-end run verified: encrypted 37 + 5, added ciphertexts, decrypted sum → 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)