### PR TITLE
Harden security-sensitive toolkit commands

### DIFF
--- a/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
@@ -1,11 +1,17 @@
 using System.Diagnostics;
+using System.Numerics;
+using System.Text.Json;
 using FluentAssertions;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Models;
 
 namespace Pixelbadger.Toolkit.Tests;
 
 public class CryptoCommandIntegrationTests : IDisposable
 {
     private readonly string _testDirectory;
+    private static readonly Lazy<PaillierKeyPair> TestKey = new(() => new HomomorphicEncryptionComponent().GenerateKey());
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     public CryptoCommandIntegrationTests()
     {
@@ -35,6 +41,14 @@ public class CryptoCommandIntegrationTests : IDisposable
         stdout.Should().Contain("Private key written to");
         File.Exists(publicKeyFile).Should().BeTrue();
         File.Exists(privateKeyFile).Should().BeTrue();
+
+        var publicKey = JsonSerializer.Deserialize<PaillierPublicKey>(await File.ReadAllTextAsync(publicKeyFile));
+        BigInteger.Parse(publicKey!.N).GetBitLength().Should().BeGreaterThanOrEqualTo(HomomorphicEncryptionComponent.MinimumKeyBitLength);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.GetUnixFileMode(privateKeyFile).Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
     }
 
     [Fact]
@@ -44,8 +58,7 @@ public class CryptoCommandIntegrationTests : IDisposable
         var privateKeyFile = Path.Combine(_testDirectory, "test.key");
         var encFile = Path.Combine(_testDirectory, "number.enc");
 
-        await RunToolkitCommandAsync("crypto", "generate-key",
-            "--public-key-file", publicKeyFile, "--private-key-file", privateKeyFile);
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
 
         var (exitCode, stdout, _) = await RunToolkitCommandAsync(
             "crypto", "encrypt", "--number", "42", "--public-key-file", publicKeyFile, "--out-file", encFile);
@@ -62,8 +75,7 @@ public class CryptoCommandIntegrationTests : IDisposable
         var privateKeyFile = Path.Combine(_testDirectory, "test.key");
         var encFile = Path.Combine(_testDirectory, "number.enc");
 
-        await RunToolkitCommandAsync("crypto", "generate-key",
-            "--public-key-file", publicKeyFile, "--private-key-file", privateKeyFile);
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
         await RunToolkitCommandAsync("crypto", "encrypt",
             "--number", "99", "--public-key-file", publicKeyFile, "--out-file", encFile);
 
@@ -83,8 +95,7 @@ public class CryptoCommandIntegrationTests : IDisposable
         var encFile2 = Path.Combine(_testDirectory, "b.enc");
         var sumFile = Path.Combine(_testDirectory, "sum.enc");
 
-        await RunToolkitCommandAsync("crypto", "generate-key",
-            "--public-key-file", publicKeyFile, "--private-key-file", privateKeyFile);
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
         await RunToolkitCommandAsync("crypto", "encrypt",
             "--number", "37", "--public-key-file", publicKeyFile, "--out-file", encFile1);
         await RunToolkitCommandAsync("crypto", "encrypt",
@@ -105,8 +116,7 @@ public class CryptoCommandIntegrationTests : IDisposable
         var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
         var privateKeyFile = Path.Combine(_testDirectory, "test.key");
 
-        await RunToolkitCommandAsync("crypto", "generate-key",
-            "--public-key-file", publicKeyFile, "--private-key-file", privateKeyFile);
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
 
         var publicJson = await File.ReadAllTextAsync(publicKeyFile);
         publicJson.Should().Contain("\"N\"");
@@ -221,4 +231,13 @@ public class CryptoCommandIntegrationTests : IDisposable
         Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
             "../../../../Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj"));
+
+    private static async Task WriteKeyFilesAsync(string publicKeyFile, string privateKeyFile)
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        await File.WriteAllTextAsync(publicKeyFile, JsonSerializer.Serialize(publicKey, JsonOptions));
+        await File.WriteAllTextAsync(privateKeyFile, JsonSerializer.Serialize(key, JsonOptions));
+    }
 }

--- a/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
@@ -7,14 +7,14 @@ namespace Pixelbadger.Toolkit.Tests;
 
 public class HomomorphicEncryptionComponentTests
 {
-    // 64-bit keys (32-bit primes) for fast test execution
-    private const int TestKeyBitLength = 64;
     private readonly HomomorphicEncryptionComponent _component = new();
+    private static readonly Lazy<PaillierKeyPair> TestKey = new(() => new HomomorphicEncryptionComponent().GenerateKey());
+    private static readonly Lazy<PaillierKeyPair> SecondTestKey = new(() => new HomomorphicEncryptionComponent().GenerateKey());
 
     [Fact]
     public void GenerateKey_ShouldReturnKeyPairWithValidPositiveBigIntegerStrings()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
 
         BigInteger.TryParse(key.N, out var n).Should().BeTrue();
         BigInteger.TryParse(key.Lambda, out var lambda).Should().BeTrue();
@@ -27,7 +27,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void GenerateKey_ShouldSatisfyPaillierKeyRelationship_MuIsModularInverseOfLambdaModN()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var n = BigInteger.Parse(key.N);
         var lambda = BigInteger.Parse(key.Lambda);
         var mu = BigInteger.Parse(key.Mu);
@@ -39,7 +39,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void Encrypt_ShouldReturnCiphertextDifferentFromPlaintext()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encrypted = _component.Encrypt(42L, publicKey);
@@ -52,7 +52,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void Encrypt_ShouldProduceProbabilisticCiphertext_SamePlaintextYieldsDifferentCiphertexts()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encrypted1 = _component.Encrypt(7L, publicKey);
@@ -65,7 +65,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void Decrypt_ShouldReturnOriginalPlaintext_WhenDecryptingEncryptedNumber()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encrypted = _component.Encrypt(42L, publicKey);
@@ -81,7 +81,7 @@ public class HomomorphicEncryptionComponentTests
     [InlineData(999999L)]
     public void Decrypt_ShouldReturnCorrectValue_ForVariousPlaintextValues(long plaintext)
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encrypted = _component.Encrypt(plaintext, publicKey);
@@ -93,7 +93,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void AddEncrypted_ShouldDecryptToSumOfOriginalValues()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encryptedA = _component.Encrypt(15L, publicKey);
@@ -107,7 +107,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void AddEncrypted_ShouldDecryptToCorrectSum_WhenAddingZero()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encryptedA = _component.Encrypt(99L, publicKey);
@@ -121,7 +121,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void AddEncrypted_ShouldReturnEncryptedNumberWithSameN_AsInputs()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var encryptedA = _component.Encrypt(5L, publicKey);
@@ -134,7 +134,7 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void Encrypt_ShouldThrowArgumentException_WhenPlaintextIsNegative()
     {
-        var key = _component.GenerateKey(TestKeyBitLength);
+        var key = TestKey.Value;
         var publicKey = new PaillierPublicKey { N = key.N };
 
         var act = () => _component.Encrypt(-1L, publicKey);
@@ -146,8 +146,8 @@ public class HomomorphicEncryptionComponentTests
     [Fact]
     public void AddEncrypted_ShouldThrowArgumentException_WhenPublicKeysDoNotMatch()
     {
-        var key1 = _component.GenerateKey(TestKeyBitLength);
-        var key2 = _component.GenerateKey(TestKeyBitLength);
+        var key1 = TestKey.Value;
+        var key2 = SecondTestKey.Value;
 
         var encrypted1 = _component.Encrypt(5L, new PaillierPublicKey { N = key1.N });
         var encrypted2 = _component.Encrypt(3L, new PaillierPublicKey { N = key2.N });
@@ -156,5 +156,14 @@ public class HomomorphicEncryptionComponentTests
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("*same public key*");
+    }
+
+    [Fact]
+    public void GenerateKey_ShouldThrowArgumentException_WhenBitLengthIsBelowSecurityMinimum()
+    {
+        var act = () => _component.GenerateKey(HomomorphicEncryptionComponent.MinimumKeyBitLength - 8);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*at least 2048 bits*");
     }
 }

--- a/Pixelbadger.Toolkit.Tests/OAuthProfileComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/OAuthProfileComponentTests.cs
@@ -77,6 +77,15 @@ public class OAuthProfileComponentTests
     }
 
     [Fact]
+    public async Task AddProfileAsync_ShouldThrow_WhenAuthorityIsNotHttps()
+    {
+        var act = async () => await _component.AddProfileAsync("dev", "http://auth.example.com", "id", "secret", null);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*absolute HTTPS URI*");
+    }
+
+    [Fact]
     public async Task AddProfileAsync_ShouldBeCaseInsensitive_WhenCheckingForDuplicates()
     {
         // Arrange
@@ -155,6 +164,21 @@ public class OAuthProfileComponentTests
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*'missing'*not found*");
+    }
+
+    [Fact]
+    public async Task UpdateProfileAsync_ShouldThrow_WhenAuthorityIsNotHttps()
+    {
+        var existing = new List<OAuthProfile>
+        {
+            new() { Name = "dev", AuthorityUri = "https://auth.example.com", ClientId = "id", ClientSecret = "secret" }
+        };
+        _mockProfileService.Setup(x => x.LoadProfilesAsync()).ReturnsAsync(existing);
+
+        var act = async () => await _component.UpdateProfileAsync("dev", "http://auth.example.com", null, null, null);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*absolute HTTPS URI*");
     }
 
     [Fact]

--- a/Pixelbadger.Toolkit.Tests/OAuthTokenComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/OAuthTokenComponentTests.cs
@@ -62,6 +62,68 @@ public class OAuthTokenComponentTests
     }
 
     [Fact]
+    public async Task GetTokenAsync_ShouldThrowBeforeDiscovery_WhenAuthorityIsNotHttps()
+    {
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "http://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = "secret"
+        };
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+
+        var act = async () => await _component.GetTokenAsync("dev", "user", "pass");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*absolute HTTPS URI*");
+        _mockHttpClient.Verify(x => x.DiscoverTokenEndpointAsync(It.IsAny<string>()), Times.Never);
+        _mockHttpClient.Verify(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldThrowBeforeRequest_WhenTokenEndpointIsNotHttps()
+    {
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = "secret"
+        };
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync("https://auth.example.com"))
+            .ReturnsAsync("http://auth.example.com/token");
+
+        var act = async () => await _component.GetTokenAsync("dev", "user", "pass");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*absolute HTTPS URI*");
+        _mockHttpClient.Verify(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldThrowBeforeRequest_WhenTokenEndpointHostDiffersFromAuthority()
+    {
+        var profile = new OAuthProfile
+        {
+            Name = "dev",
+            AuthorityUri = "https://auth.example.com",
+            ClientId = "client-id",
+            ClientSecret = "secret"
+        };
+        _mockProfileService.Setup(x => x.GetProfileAsync("dev")).ReturnsAsync(profile);
+        _mockHttpClient.Setup(x => x.DiscoverTokenEndpointAsync("https://auth.example.com"))
+            .ReturnsAsync("https://evil.example.com/token");
+
+        var act = async () => await _component.GetTokenAsync("dev", "user", "pass");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*host must match*");
+        _mockHttpClient.Verify(x => x.RequestTokenAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
+    }
+
+    [Fact]
     public async Task GetTokenAsync_ShouldIncludeClientSecret_WhenProfileHasOne()
     {
         // Arrange

--- a/Pixelbadger.Toolkit.Tests/WebCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/WebCommandIntegrationTests.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using FluentAssertions;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class WebCommandIntegrationTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public WebCommandIntegrationTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+            Directory.Delete(_testDirectory, true);
+    }
+
+    [Fact]
+    public async Task ServeHtml_ShouldNotExposeSiblingFiles_WhenFileIsServed()
+    {
+        var htmlFile = Path.Combine(_testDirectory, "index.html");
+        var secretFile = Path.Combine(_testDirectory, "secret.txt");
+        await File.WriteAllTextAsync(htmlFile, "<h1>Hello</h1>");
+        await File.WriteAllTextAsync(secretFile, "do not serve");
+
+        var port = GetAvailablePort();
+        using var process = StartToolkitCommand("web", "serve-html", "--file", htmlFile, "--port", port.ToString());
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            await WaitForServerAsync(httpClient, port, process);
+
+            var root = await httpClient.GetStringAsync($"http://localhost:{port}/");
+            var siblingResponse = await httpClient.GetAsync($"http://localhost:{port}/secret.txt");
+
+            root.Should().Be("<h1>Hello</h1>");
+            siblingResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync();
+            }
+        }
+    }
+
+    private static Process StartToolkitCommand(params string[] args)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(GetToolkitProjectPath());
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("Debug");
+        startInfo.ArgumentList.Add("--no-build");
+        startInfo.ArgumentList.Add("--");
+
+        foreach (var arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        return Process.Start(startInfo)!;
+    }
+
+    private static async Task WaitForServerAsync(HttpClient httpClient, int port, Process process)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (process.HasExited)
+            {
+                var stdout = await process.StandardOutput.ReadToEndAsync();
+                var stderr = await process.StandardError.ReadToEndAsync();
+                throw new InvalidOperationException($"Server exited early. stdout: {stdout} stderr: {stderr}");
+            }
+
+            try
+            {
+                using var response = await httpClient.GetAsync($"http://localhost:{port}/");
+                if (response.IsSuccessStatusCode)
+                    return;
+            }
+            catch (HttpRequestException)
+            {
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("Timed out waiting for web server to start.");
+    }
+
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static string GetToolkitProjectPath() =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "../../../../Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj"));
+}

--- a/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
@@ -51,7 +51,7 @@ public static class CryptoCommand
                 var publicKey = new PaillierPublicKey { N = keyPair.N };
 
                 await File.WriteAllTextAsync(publicKeyFile, JsonSerializer.Serialize(publicKey, JsonOptions));
-                await File.WriteAllTextAsync(privateKeyFile, JsonSerializer.Serialize(keyPair, JsonOptions));
+                await WriteOwnerOnlyTextAsync(privateKeyFile, JsonSerializer.Serialize(keyPair, JsonOptions));
 
                 Console.WriteLine($"Public key written to '{publicKeyFile}'");
                 Console.WriteLine($"Private key written to '{privateKeyFile}'");
@@ -223,5 +223,16 @@ public static class CryptoCommand
         }, inFile1Option, inFile2Option, outFileOption);
 
         return command;
+    }
+
+    private static async Task WriteOwnerOnlyTextAsync(string path, string contents)
+    {
+        if (!OperatingSystem.IsWindows() && File.Exists(path))
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        await File.WriteAllTextAsync(path, contents);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 }

--- a/Pixelbadger.Toolkit/Commands/WebCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/WebCommand.cs
@@ -2,7 +2,6 @@ using System.CommandLine;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 
 namespace Pixelbadger.Toolkit.Commands;
@@ -54,16 +53,6 @@ public static class WebCommand
                 var builder = WebApplication.CreateBuilder();
                 var app = builder.Build();
 
-                var fileInfo = new FileInfo(file);
-                var directory = fileInfo.Directory?.FullName ?? Directory.GetCurrentDirectory();
-                var fileName = fileInfo.Name;
-
-                app.UseStaticFiles(new StaticFileOptions
-                {
-                    FileProvider = new PhysicalFileProvider(directory),
-                    RequestPath = ""
-                });
-
                 var fileContent = await File.ReadAllTextAsync(file);
                 var contentType = Path.GetExtension(file).ToLowerInvariant() switch
                 {
@@ -79,6 +68,12 @@ public static class WebCommand
                 {
                     context.Response.ContentType = contentType;
                     await context.Response.WriteAsync(fileContent);
+                });
+
+                app.MapGet("/{*path}", context =>
+                {
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return Task.CompletedTask;
                 });
 
                 Console.WriteLine($"Serving '{file}' on http://localhost:{port}");

--- a/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
+++ b/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
@@ -6,15 +6,20 @@ namespace Pixelbadger.Toolkit.Components;
 
 public class HomomorphicEncryptionComponent
 {
-    public PaillierKeyPair GenerateKey(int bitLength = 512)
+    public const int DefaultKeyBitLength = 2048;
+    public const int MinimumKeyBitLength = 2048;
+
+    public PaillierKeyPair GenerateKey(int bitLength = DefaultKeyBitLength)
     {
+        ValidateKeyBitLength(bitLength);
+
         using var rng = RandomNumberGenerator.Create();
         BigInteger p, q;
         do
         {
             p = GeneratePrime(bitLength / 2, rng);
             q = GeneratePrime(bitLength / 2, rng);
-        } while (p == q);
+        } while (p == q || (p * q).GetBitLength() < bitLength);
 
         var n = p * q;
         var lambda = Lcm(p - 1, q - 1);
@@ -34,6 +39,7 @@ public class HomomorphicEncryptionComponent
             throw new ArgumentException("Plaintext must be non-negative.", nameof(plaintext));
 
         var n = BigInteger.Parse(publicKey.N);
+        ValidateModulus(n);
         var m = new BigInteger(plaintext);
 
         if (m >= n)
@@ -61,6 +67,7 @@ public class HomomorphicEncryptionComponent
     public BigInteger Decrypt(EncryptedNumber encryptedNumber, PaillierKeyPair key)
     {
         var n = BigInteger.Parse(key.N);
+        ValidateModulus(n);
         var lambda = BigInteger.Parse(key.Lambda);
         var mu = BigInteger.Parse(key.Mu);
         var c = BigInteger.Parse(encryptedNumber.Ciphertext);
@@ -76,6 +83,7 @@ public class HomomorphicEncryptionComponent
             throw new ArgumentException("Both encrypted numbers must use the same public key (N).");
 
         var n = BigInteger.Parse(a.N);
+        ValidateModulus(n);
         var nSquared = n * n;
         var c1 = BigInteger.Parse(a.Ciphertext);
         var c2 = BigInteger.Parse(b.Ciphertext);
@@ -88,6 +96,21 @@ public class HomomorphicEncryptionComponent
     }
 
     private static BigInteger L(BigInteger x, BigInteger n) => (x - 1) / n;
+
+    private static void ValidateKeyBitLength(int bitLength)
+    {
+        if (bitLength < MinimumKeyBitLength)
+            throw new ArgumentException($"Paillier keys must be at least {MinimumKeyBitLength} bits.", nameof(bitLength));
+
+        if (bitLength % 2 != 0 || bitLength % 8 != 0)
+            throw new ArgumentException("Paillier key bit length must be divisible by 8 and 2.", nameof(bitLength));
+    }
+
+    private static void ValidateModulus(BigInteger n)
+    {
+        if (n.GetBitLength() < MinimumKeyBitLength)
+            throw new ArgumentException($"Paillier modulus must be at least {MinimumKeyBitLength} bits.");
+    }
 
     private static BigInteger Lcm(BigInteger a, BigInteger b) =>
         a / BigInteger.GreatestCommonDivisor(a, b) * b;

--- a/Pixelbadger.Toolkit/Components/OAuthProfileComponent.cs
+++ b/Pixelbadger.Toolkit/Components/OAuthProfileComponent.cs
@@ -7,6 +7,8 @@ public class OAuthProfileComponent(IOAuthProfileService profileService)
 {
     public async Task AddProfileAsync(string name, string authorityUri, string clientId, string clientSecret, string? scope)
     {
+        ValidateHttpsUri(authorityUri, "authority URI");
+
         var profiles = await profileService.LoadProfilesAsync();
 
         if (profiles.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
@@ -30,7 +32,11 @@ public class OAuthProfileComponent(IOAuthProfileService profileService)
         var profile = profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Profile '{name}' not found.");
 
-        if (authorityUri is not null) profile.AuthorityUri = authorityUri;
+        if (authorityUri is not null)
+        {
+            ValidateHttpsUri(authorityUri, "authority URI");
+            profile.AuthorityUri = authorityUri;
+        }
         if (clientId is not null) profile.ClientId = clientId;
         if (clientSecret is not null) profile.ClientSecret = clientSecret;
         if (scope is not null) profile.Scope = scope;
@@ -46,5 +52,13 @@ public class OAuthProfileComponent(IOAuthProfileService profileService)
 
         profiles.Remove(profile);
         await profileService.SaveProfilesAsync(profiles);
+    }
+
+    private static Uri ValidateHttpsUri(string value, string description)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            throw new ArgumentException($"OAuth {description} must be an absolute HTTPS URI.");
+
+        return uri;
     }
 }

--- a/Pixelbadger.Toolkit/Components/OAuthTokenComponent.cs
+++ b/Pixelbadger.Toolkit/Components/OAuthTokenComponent.cs
@@ -9,7 +9,12 @@ public class OAuthTokenComponent(IOAuthProfileService profileService, IOAuthHttp
         var profile = await profileService.GetProfileAsync(profileName)
             ?? throw new InvalidOperationException($"Profile '{profileName}' not found.");
 
+        var authorityUri = ValidateHttpsUri(profile.AuthorityUri, "authority URI");
         var tokenEndpoint = await httpClient.DiscoverTokenEndpointAsync(profile.AuthorityUri);
+        var tokenEndpointUri = ValidateHttpsUri(tokenEndpoint, "token endpoint");
+
+        if (!string.Equals(authorityUri.Host, tokenEndpointUri.Host, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("OAuth token endpoint host must match the authority host.");
 
         var parameters = new Dictionary<string, string>
         {
@@ -31,5 +36,13 @@ public class OAuthTokenComponent(IOAuthProfileService profileService, IOAuthHttp
             throw new InvalidOperationException("Token response did not contain an access token.");
 
         return tokenResponse.AccessToken;
+    }
+
+    private static Uri ValidateHttpsUri(string value, string description)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            throw new InvalidOperationException($"OAuth {description} must be an absolute HTTPS URI.");
+
+        return uri;
     }
 }

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;openai;crypto;homomorphic-encryption</PackageTags>

--- a/Pixelbadger.Toolkit/Services/OAuthHttpClient.cs
+++ b/Pixelbadger.Toolkit/Services/OAuthHttpClient.cs
@@ -10,6 +10,7 @@ public class OAuthHttpClient : IOAuthHttpClient
 
     public async Task<string> DiscoverTokenEndpointAsync(string authorityUri)
     {
+        var authority = ValidateHttpsUri(authorityUri, "authority URI");
         var discoveryUrl = $"{authorityUri.TrimEnd('/')}/.well-known/openid-configuration";
         var response = await _httpClient.GetAsync(discoveryUrl);
         response.EnsureSuccessStatusCode();
@@ -20,12 +21,20 @@ public class OAuthHttpClient : IOAuthHttpClient
         if (!document.RootElement.TryGetProperty("token_endpoint", out var tokenEndpointElement))
             throw new InvalidOperationException($"OIDC discovery document from '{discoveryUrl}' does not contain 'token_endpoint'.");
 
-        return tokenEndpointElement.GetString()
+        var tokenEndpoint = tokenEndpointElement.GetString()
             ?? throw new InvalidOperationException("'token_endpoint' in OIDC discovery document is null.");
+
+        var tokenEndpointUri = ValidateHttpsUri(tokenEndpoint, "token endpoint");
+        if (!string.Equals(authority.Host, tokenEndpointUri.Host, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("OIDC token endpoint host must match the authority host.");
+
+        return tokenEndpoint;
     }
 
     public async Task<OAuthTokenResponse> RequestTokenAsync(string tokenEndpoint, Dictionary<string, string> parameters)
     {
+        ValidateHttpsUri(tokenEndpoint, "token endpoint");
+
         var content = new FormUrlEncodedContent(parameters);
         var response = await _httpClient.PostAsync(tokenEndpoint, content);
         response.EnsureSuccessStatusCode();
@@ -51,5 +60,13 @@ public class OAuthHttpClient : IOAuthHttpClient
 
         [JsonPropertyName("expires_in")]
         public int? ExpiresIn { get; set; }
+    }
+
+    private static Uri ValidateHttpsUri(string value, string description)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            throw new InvalidOperationException($"OAuth {description} must be an absolute HTTPS URI.");
+
+        return uri;
     }
 }

--- a/Pixelbadger.Toolkit/Services/OAuthProfileService.cs
+++ b/Pixelbadger.Toolkit/Services/OAuthProfileService.cs
@@ -24,8 +24,14 @@ public class OAuthProfileService : IOAuthProfileService
         var directory = Path.GetDirectoryName(ProfilesFilePath)!;
         Directory.CreateDirectory(directory);
 
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
         var json = JsonSerializer.Serialize(profiles, new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(ProfilesFilePath, json);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(ProfilesFilePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
     }
 
     public async Task<OAuthProfile?> GetProfileAsync(string name)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pixelbadger.Toolkit
 
-A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.
+A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, OAuth utilities, and homomorphic encryption.
 
 > **Note**: Search and MCP RAG functionality has been extracted to the separate [Pixelbadger.Toolkit.Rag](https://github.com/pixelbadger/Pixelbadger.Toolkit.Rag) repository (`pbrag` CLI tool).
 
@@ -26,6 +26,9 @@ A CLI toolkit exposing varied functionality organized by topic, including string
     - [translate](#translate)
     - [ocaaar](#ocaaar)
     - [corpospeak](#corpospeak)
+  - [oauth](#oauth)
+    - [token](#token)
+    - [profile](#profile)
   - [crypto](#crypto)
     - [generate-key](#generate-key)
     - [encrypt](#encrypt)
@@ -233,7 +236,7 @@ pbtk images steganography --mode decode --image encoded.png
 Web server utilities.
 
 #### serve-html
-Serves a static HTML file via HTTP server.
+Serves a single static HTML file via HTTP server.
 
 **Usage:**
 ```bash
@@ -243,6 +246,9 @@ pbtk web serve-html --file <html-file> [--port <port>]
 **Options:**
 - `--file`: Path to the HTML file to serve (required)
 - `--port`: Port to bind the server to (default: 8080)
+
+**Details:**
+- Only the requested file is served from `/`; sibling files in the same directory are not exposed.
 
 **Examples:**
 ```bash
@@ -421,10 +427,33 @@ pbtk openai corpospeak --source "Database migration finished" --audience "operat
 - **hr**: People impact and organizational dynamics
 - **customer-success**: Customer experience and support focus
 
+### oauth
+OAuth utilities for managing local profiles and acquiring access tokens with Resource Owner Password Credentials.
+
+> **Security note**: OAuth authorities and discovered token endpoints must be absolute HTTPS URIs. The discovered token endpoint host must match the configured authority host before credentials are sent.
+
+#### token
+Acquires an OAuth access token using a saved profile. The command prompts for username and password, then prints the access token.
+
+**Usage:**
+```bash
+pbtk oauth token --profile <profile-name>
+```
+
+#### profile
+Manages OAuth profiles stored under the current user's home directory. On Unix-like systems, the profile directory is restricted to owner access and the profile file is written with owner read/write permissions.
+
+**Usage:**
+```bash
+pbtk oauth profile add --name <profile-name> --authority <https-authority-uri> --client-id <client-id> [--client-secret <client-secret>] [--scope <scope>]
+pbtk oauth profile update --name <profile-name> [--authority <https-authority-uri>] [--client-id <client-id>] [--client-secret <client-secret>] [--scope <scope>]
+pbtk oauth profile delete --name <profile-name>
+```
+
 ### crypto
 Homomorphic encryption utilities using the Paillier cryptosystem. Encrypted numbers can be added together without ever decrypting them — the result decrypts to the correct sum.
 
-> **Security note**: `generate-key` produces two separate files: a **public key** file (contains only `N`) which is safe to distribute to anyone who needs to encrypt values for you, and a **private key** file (contains `N`, `Lambda`, `Mu`) which must be kept secret and is required only for decryption.
+> **Security note**: `generate-key` produces a 2048-bit Paillier key pair in two separate files: a **public key** file (contains only `N`) which is safe to distribute to anyone who needs to encrypt values for you, and a **private key** file (contains `N`, `Lambda`, `Mu`) which must be kept secret and is required only for decryption. On Unix-like systems, private key files are written with owner read/write permissions only.
 
 #### generate-key
 Generates a Paillier key pair and writes separate public and private key files.
@@ -531,14 +560,7 @@ The steganography feature uses LSB (Least Significant Bit) encoding to hide mess
 - **Ook**: A Brainfuck derivative using "Ook." and "Ook?" syntax inspired by Terry Pratchett's Discworld orangutans
 
 ### Homomorphic Encryption Implementation
-The `crypto` topic uses the simplified Paillier cryptosystem, a partially homomorphic encryption scheme supporting additive operations on ciphertexts. Key generation uses Miller-Rabin primality testing (20 witnesses) via `System.Security.Cryptography.RandomNumberGenerator`. All big-integer arithmetic is performed using `System.Numerics.BigInteger` — no third-party cryptography library is required. The default key size is 512 bits; ciphertexts live in Z_{n²} and are therefore approximately 1024 bits in length. The scheme is partially homomorphic: addition of plaintexts corresponds to multiplication of their ciphertexts modulo n².
+The `crypto` topic uses the simplified Paillier cryptosystem, a partially homomorphic encryption scheme supporting additive operations on ciphertexts. Key generation uses Miller-Rabin primality testing (20 witnesses) via `System.Security.Cryptography.RandomNumberGenerator`. All big-integer arithmetic is performed using `System.Numerics.BigInteger` — no third-party cryptography library is required. The default and minimum key size is 2048 bits; ciphertexts live in Z_{n²} and are therefore approximately 4096 bits in length. The scheme is partially homomorphic: addition of plaintexts corresponds to multiplication of their ciphertexts modulo n².
 
 #### Performance
-Homomorphic addition (`add` command) operates on ~1024-bit `BigInteger` values (multiply + modular reduction over n²). Benchmarked on .NET 9 ARM64 against plain `long` addition:
-
-| Operation | Mean | Allocated |
-|---|---|---|
-| Regular `long` addition | ~0.2 ns | 0 B |
-| Homomorphic add (in-memory BigInteger) | ~2,777 ns | 432 B |
-
-The homomorphic operation is roughly **14,000× slower** than native integer addition and allocates ~432 bytes per call due to intermediate `BigInteger` heap objects. This is the irreducible cost of arbitrary-precision modular arithmetic on 512-bit keys — not parsing overhead.
+Homomorphic addition (`add` command) operates on ~4096-bit `BigInteger` values (multiply + modular reduction over n²). It is significantly slower than native integer addition due to arbitrary-precision modular arithmetic and intermediate `BigInteger` heap objects.


### PR DESCRIPTION
## Summary
- Increase Paillier key security by enforcing 2048-bit minimum keys and owner-only private key permissions on Unix-like systems.
- Harden OAuth credential handling by requiring HTTPS authorities/token endpoints, matching token endpoint hosts, and restrictive profile file permissions.
- Restrict `web serve-html` to only serve the requested file and document the security-sensitive behavior changes.

## Tests
- `dotnet build`
- `dotnet test --no-build`