### PR TITLE
Add homomorphic substring command to crypto topic

### DIFF
--- a/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CryptoCommandIntegrationTests.cs
@@ -178,6 +178,290 @@ public class CryptoCommandIntegrationTests : IDisposable
     }
 
     [Fact]
+    public async Task EncryptString_ThenDecryptString_ShouldReturnOriginalString()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hello world", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt-string", "--in-file", encFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("hello world");
+    }
+
+    [Fact]
+    public async Task Replace_ShouldProduceUpdatedStringAfterDecryption()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+        var updatedFile = Path.Combine(_testDirectory, "updated.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hello world", "--public-key-file", publicKeyFile, "--out-file", encFile);
+        await RunToolkitCommandAsync("crypto", "replace",
+            "--in-file", encFile, "--start", "6", "--replacement", "there", "--out-file", updatedFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt-string", "--in-file", updatedFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("hello there");
+    }
+
+    [Fact]
+    public async Task Replace_ShouldReturnFailure_WhenRangeExceedsStringLength()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+        var updatedFile = Path.Combine(_testDirectory, "updated.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hi", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "replace", "--in-file", encFile, "--start", "1", "--replacement", "xyz", "--out-file", updatedFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task EncryptString_ShouldReturnFailure_WhenStringExceedsMaxLength()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        var tooLong = new string('a', 101);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "encrypt-string", "--string", tooLong, "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Multiply_ShouldProduceEncryptedProductThatDecryptsToCorrectValue()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "a.enc");
+        var productFile = Path.Combine(_testDirectory, "product.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "7", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "multiply", "--in-file", encFile, "--scalar", "6", "--out-file", productFile);
+
+        exitCode.Should().Be(0);
+        stdout.Should().Contain("Encrypted product written to");
+
+        var (decryptExitCode, decryptStdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", productFile, "--private-key-file", privateKeyFile);
+        decryptExitCode.Should().Be(0);
+        decryptStdout.Trim().Should().Be("42");
+    }
+
+    [Fact]
+    public async Task Multiply_ShouldProduceEncryptedZero_WhenScalarIsZero()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "a.enc");
+        var productFile = Path.Combine(_testDirectory, "product.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "99", "--public-key-file", publicKeyFile, "--out-file", encFile);
+        await RunToolkitCommandAsync("crypto", "multiply",
+            "--in-file", encFile, "--scalar", "0", "--out-file", productFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", productFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("0");
+    }
+
+    [Fact]
+    public async Task Multiply_ShouldReturnFailure_WhenScalarIsNegative()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "a.enc");
+        var productFile = Path.Combine(_testDirectory, "product.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "5", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "multiply", "--in-file", encFile, "--scalar", "-3", "--out-file", productFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Subtract_ShouldProduceEncryptedDifferenceThatDecryptsToCorrectValue()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile1 = Path.Combine(_testDirectory, "a.enc");
+        var encFile2 = Path.Combine(_testDirectory, "b.enc");
+        var diffFile = Path.Combine(_testDirectory, "diff.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "100", "--public-key-file", publicKeyFile, "--out-file", encFile1);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "58", "--public-key-file", publicKeyFile, "--out-file", encFile2);
+        await RunToolkitCommandAsync("crypto", "subtract",
+            "--in-file1", encFile1, "--in-file2", encFile2, "--out-file", diffFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", diffFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("42");
+    }
+
+    [Fact]
+    public async Task Subtract_ShouldProduceEncryptedZero_WhenValuesAreEqual()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile1 = Path.Combine(_testDirectory, "a.enc");
+        var encFile2 = Path.Combine(_testDirectory, "b.enc");
+        var diffFile = Path.Combine(_testDirectory, "diff.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "77", "--public-key-file", publicKeyFile, "--out-file", encFile1);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "77", "--public-key-file", publicKeyFile, "--out-file", encFile2);
+        await RunToolkitCommandAsync("crypto", "subtract",
+            "--in-file1", encFile1, "--in-file2", encFile2, "--out-file", diffFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt", "--in-file", diffFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("0");
+    }
+
+    [Fact]
+    public async Task Subtract_ShouldReturnFailure_WhenFirstInputFileDoesNotExist()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var missingFile = Path.Combine(_testDirectory, "missing.enc");
+        var encFile = Path.Combine(_testDirectory, "b.enc");
+        var diffFile = Path.Combine(_testDirectory, "diff.enc");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt",
+            "--number", "5", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "subtract", "--in-file1", missingFile, "--in-file2", encFile, "--out-file", diffFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Substring_ShouldProduceSliceThatDecryptsToCorrectValue()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+        var subFile = Path.Combine(_testDirectory, "sub.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hello world", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "substring", "--in-file", encFile, "--start", "6", "--length", "5", "--out-file", subFile);
+
+        exitCode.Should().Be(0);
+        stdout.Should().Contain("Encrypted substring (5 characters) written to");
+
+        var (decryptExitCode, decryptStdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt-string", "--in-file", subFile, "--private-key-file", privateKeyFile);
+        decryptExitCode.Should().Be(0);
+        decryptStdout.Trim().Should().Be("world");
+    }
+
+    [Fact]
+    public async Task Substring_ShouldDecryptToRemainder_WhenLengthIsOmitted()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+        var subFile = Path.Combine(_testDirectory, "sub.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hello world", "--public-key-file", publicKeyFile, "--out-file", encFile);
+        await RunToolkitCommandAsync("crypto", "substring",
+            "--in-file", encFile, "--start", "6", "--out-file", subFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "decrypt-string", "--in-file", subFile, "--private-key-file", privateKeyFile);
+
+        exitCode.Should().Be(0);
+        stdout.Trim().Should().Be("world");
+    }
+
+    [Fact]
+    public async Task Substring_ShouldReturnFailure_WhenRangeExceedsStringLength()
+    {
+        var publicKeyFile = Path.Combine(_testDirectory, "test.pub");
+        var privateKeyFile = Path.Combine(_testDirectory, "test.key");
+        var encFile = Path.Combine(_testDirectory, "msg.estr");
+        var subFile = Path.Combine(_testDirectory, "sub.estr");
+
+        await WriteKeyFilesAsync(publicKeyFile, privateKeyFile);
+        await RunToolkitCommandAsync("crypto", "encrypt-string",
+            "--string", "hi", "--public-key-file", publicKeyFile, "--out-file", encFile);
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "substring", "--in-file", encFile, "--start", "1", "--length", "5", "--out-file", subFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
+    public async Task Substring_ShouldReturnFailure_WhenInputFileDoesNotExist()
+    {
+        var missingFile = Path.Combine(_testDirectory, "missing.estr");
+        var subFile = Path.Combine(_testDirectory, "sub.estr");
+
+        var (exitCode, stdout, _) = await RunToolkitCommandAsync(
+            "crypto", "substring", "--in-file", missingFile, "--start", "0", "--out-file", subFile);
+
+        exitCode.Should().Be(1);
+        stdout.Should().Contain("Error:");
+    }
+
+    [Fact]
     public async Task Add_ShouldReturnFailure_WhenFirstInputFileDoesNotExist()
     {
         var publicKeyFile = Path.Combine(_testDirectory, "test.pub");

--- a/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/HomomorphicEncryptionComponentTests.cs
@@ -131,6 +131,202 @@ public class HomomorphicEncryptionComponentTests
         encryptedSum.N.Should().Be(key.N);
     }
 
+    [Theory]
+    [InlineData(5L, 3L, 15L)]
+    [InlineData(10L, 10L, 100L)]
+    [InlineData(42L, 1L, 42L)]
+    [InlineData(99L, 0L, 0L)]
+    public void MultiplyEncrypted_ShouldDecryptToProduct_ForVariousScalars(long plaintext, long scalar, long expected)
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.Encrypt(plaintext, publicKey);
+        var product = _component.MultiplyEncrypted(encrypted, scalar);
+        var decrypted = _component.Decrypt(product, key);
+
+        decrypted.Should().Be(new BigInteger(expected));
+    }
+
+    [Fact]
+    public void MultiplyEncrypted_ShouldReturnEncryptedNumberWithSameN()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.Encrypt(7L, publicKey);
+        var product = _component.MultiplyEncrypted(encrypted, 3L);
+
+        product.N.Should().Be(key.N);
+    }
+
+    [Theory]
+    [InlineData("hello")]
+    [InlineData("Hello, World!")]
+    [InlineData("café")]
+    [InlineData("")]
+    public void EncryptString_ThenDecryptString_ShouldReturnOriginal(string plaintext)
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString(plaintext, publicKey);
+        var decrypted = _component.DecryptString(encrypted, key);
+
+        decrypted.Should().Be(plaintext);
+    }
+
+    [Fact]
+    public void EncryptString_ShouldEncryptOneCodePointPerCharacter()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+
+        encrypted.Characters.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void EncryptString_ShouldThrowArgumentException_WhenStringExceedsMaxLength()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+        var tooLong = new string('a', HomomorphicEncryptionComponent.MaxStringLength + 1);
+
+        var act = () => _component.EncryptString(tooLong, publicKey);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage($"*{HomomorphicEncryptionComponent.MaxStringLength} characters*");
+    }
+
+    [Fact]
+    public void ReplaceInString_ShouldDecryptToUpdatedString_WhenReplacingMiddleChars()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello world", publicKey);
+        var replaced = _component.ReplaceInString(encrypted, 6, "there");
+        var decrypted = _component.DecryptString(replaced, key);
+
+        decrypted.Should().Be("hello there");
+    }
+
+    [Fact]
+    public void ReplaceInString_ShouldDecryptToUpdatedString_WhenReplacingAtStart()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var replaced = _component.ReplaceInString(encrypted, 0, "H");
+        var decrypted = _component.DecryptString(replaced, key);
+
+        decrypted.Should().Be("Hello");
+    }
+
+    [Fact]
+    public void ReplaceInString_ShouldDecryptToUpdatedString_WhenReplacingAtEnd()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var replaced = _component.ReplaceInString(encrypted, 3, "p!");
+        var decrypted = _component.DecryptString(replaced, key);
+
+        decrypted.Should().Be("help!");
+    }
+
+    [Fact]
+    public void ReplaceInString_ShouldNotModifyOtherCharacters_WhenReplacingSubset()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("abcde", publicKey);
+        var originalCiphertext0 = encrypted.Characters[0].Ciphertext;
+        var originalCiphertext4 = encrypted.Characters[4].Ciphertext;
+
+        var replaced = _component.ReplaceInString(encrypted, 2, "X");
+
+        replaced.Characters[0].Ciphertext.Should().Be(originalCiphertext0);
+        replaced.Characters[4].Ciphertext.Should().Be(originalCiphertext4);
+    }
+
+    [Fact]
+    public void ReplaceInString_ShouldThrowArgumentException_WhenRangeExceedsStringLength()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hi", publicKey);
+
+        var act = () => _component.ReplaceInString(encrypted, 1, "xyz");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*exceeds string length*");
+    }
+
+    [Fact]
+    public void MultiplyEncrypted_ShouldThrowArgumentException_WhenScalarIsNegative()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+        var encrypted = _component.Encrypt(5L, publicKey);
+
+        var act = () => _component.MultiplyEncrypted(encrypted, -1L);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*non-negative*");
+    }
+
+    [Theory]
+    [InlineData(100L, 37L, 63L)]
+    [InlineData(42L, 42L, 0L)]
+    [InlineData(1L, 0L, 1L)]
+    public void SubtractEncrypted_ShouldDecryptToDifference_WhenAGreaterThanOrEqualToB(long a, long b, long expected)
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encA = _component.Encrypt(a, publicKey);
+        var encB = _component.Encrypt(b, publicKey);
+        var difference = _component.SubtractEncrypted(encA, encB);
+        var decrypted = _component.Decrypt(difference, key);
+
+        decrypted.Should().Be(new BigInteger(expected));
+    }
+
+    [Fact]
+    public void SubtractEncrypted_ShouldReturnEncryptedNumberWithSameN()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encA = _component.Encrypt(10L, publicKey);
+        var encB = _component.Encrypt(3L, publicKey);
+        var difference = _component.SubtractEncrypted(encA, encB);
+
+        difference.N.Should().Be(key.N);
+    }
+
+    [Fact]
+    public void SubtractEncrypted_ShouldThrowArgumentException_WhenPublicKeysDoNotMatch()
+    {
+        var key1 = TestKey.Value;
+        var key2 = SecondTestKey.Value;
+
+        var encA = _component.Encrypt(10L, new PaillierPublicKey { N = key1.N });
+        var encB = _component.Encrypt(3L, new PaillierPublicKey { N = key2.N });
+
+        var act = () => _component.SubtractEncrypted(encA, encB);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*same public key*");
+    }
+
     [Fact]
     public void Encrypt_ShouldThrowArgumentException_WhenPlaintextIsNegative()
     {
@@ -165,5 +361,124 @@ public class HomomorphicEncryptionComponentTests
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("*at least 2048 bits*");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldReturnCorrectSlice_WhenStartAndLengthProvided()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello world", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 6, 5);
+        var decrypted = _component.DecryptString(substring, key);
+
+        decrypted.Should().Be("world");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldReturnRemainderOfString_WhenLengthIsOmitted()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello world", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 6);
+        var decrypted = _component.DecryptString(substring, key);
+
+        decrypted.Should().Be("world");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldReturnFullString_WhenStartIsZeroAndLengthIsOmitted()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 0);
+        var decrypted = _component.DecryptString(substring, key);
+
+        decrypted.Should().Be("hello");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldReturnEmptyString_WhenLengthIsZero()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 2, 0);
+
+        substring.Characters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldReturnSingleCharacter_WhenLengthIsOne()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 1, 1);
+        var decrypted = _component.DecryptString(substring, key);
+
+        decrypted.Should().Be("e");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldNotShareCharacterReferences_WithOriginal()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+        var substring = _component.SubstringEncrypted(encrypted, 0, 3);
+
+        substring.Characters.Should().HaveCount(3);
+        substring.Characters[0].Should().BeSameAs(encrypted.Characters[0]);
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldThrowArgumentException_WhenStartIsNegative()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+
+        var act = () => _component.SubstringEncrypted(encrypted, -1);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*non-negative*");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldThrowArgumentException_WhenRangeExceedsStringLength()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+
+        var act = () => _component.SubstringEncrypted(encrypted, 3, 5);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*exceeds string length*");
+    }
+
+    [Fact]
+    public void SubstringEncrypted_ShouldThrowArgumentException_WhenLengthIsNegative()
+    {
+        var key = TestKey.Value;
+        var publicKey = new PaillierPublicKey { N = key.N };
+
+        var encrypted = _component.EncryptString("hello", publicKey);
+
+        var act = () => _component.SubstringEncrypted(encrypted, 0, -1);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*non-negative*");
     }
 }

--- a/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
@@ -17,6 +17,12 @@ public static class CryptoCommand
         command.AddCommand(CreateEncryptCommand());
         command.AddCommand(CreateDecryptCommand());
         command.AddCommand(CreateAddCommand());
+        command.AddCommand(CreateSubtractCommand());
+        command.AddCommand(CreateMultiplyCommand());
+        command.AddCommand(CreateEncryptStringCommand());
+        command.AddCommand(CreateDecryptStringCommand());
+        command.AddCommand(CreateReplaceCommand());
+        command.AddCommand(CreateSubstringCommand());
 
         return command;
     }
@@ -221,6 +227,336 @@ public static class CryptoCommand
                 Environment.Exit(1);
             }
         }, inFile1Option, inFile2Option, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateSubtractCommand()
+    {
+        var command = new Command("subtract", "Homomorphically subtract two encrypted numbers without decrypting them");
+
+        var inFile1Option = new Option<string>(
+            aliases: ["--in-file1"],
+            description: "Path to the first encrypted number JSON file (minuend)")
+        {
+            IsRequired = true
+        };
+
+        var inFile2Option = new Option<string>(
+            aliases: ["--in-file2"],
+            description: "Path to the second encrypted number JSON file (subtrahend)")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted difference JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFile1Option);
+        command.AddOption(inFile2Option);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string inFile1, string inFile2, string outFile) =>
+        {
+            try
+            {
+                var enc1Json = await File.ReadAllTextAsync(inFile1);
+                var encrypted1 = JsonSerializer.Deserialize<EncryptedNumber>(enc1Json)
+                    ?? throw new InvalidOperationException("Failed to deserialize first encrypted number.");
+
+                var enc2Json = await File.ReadAllTextAsync(inFile2);
+                var encrypted2 = JsonSerializer.Deserialize<EncryptedNumber>(enc2Json)
+                    ?? throw new InvalidOperationException("Failed to deserialize second encrypted number.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var difference = component.SubtractEncrypted(encrypted1, encrypted2);
+
+                var json = JsonSerializer.Serialize(difference, JsonOptions);
+                await File.WriteAllTextAsync(outFile, json);
+                Console.WriteLine($"Encrypted difference written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFile1Option, inFile2Option, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateMultiplyCommand()
+    {
+        var command = new Command("multiply", "Homomorphically multiply an encrypted number by a plaintext scalar without decrypting it");
+
+        var inFileOption = new Option<string>(
+            aliases: ["--in-file"],
+            description: "Path to the encrypted number JSON file")
+        {
+            IsRequired = true
+        };
+
+        var scalarOption = new Option<long>(
+            aliases: ["--scalar"],
+            description: "The non-negative plaintext integer to multiply by")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted product JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFileOption);
+        command.AddOption(scalarOption);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string inFile, long scalar, string outFile) =>
+        {
+            try
+            {
+                var encJson = await File.ReadAllTextAsync(inFile);
+                var encrypted = JsonSerializer.Deserialize<EncryptedNumber>(encJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize encrypted number.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var product = component.MultiplyEncrypted(encrypted, scalar);
+
+                var json = JsonSerializer.Serialize(product, JsonOptions);
+                await File.WriteAllTextAsync(outFile, json);
+                Console.WriteLine($"Encrypted product written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFileOption, scalarOption, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateEncryptStringCommand()
+    {
+        var command = new Command("encrypt-string", "Encrypt a UTF-8 string (max 100 characters) as an array of homomorphically encrypted code points");
+
+        var stringOption = new Option<string>(
+            aliases: ["--string"],
+            description: "The plaintext string to encrypt (max 100 characters)")
+        {
+            IsRequired = true
+        };
+
+        var publicKeyFileOption = new Option<string>(
+            aliases: ["--public-key-file"],
+            description: "Path to the public key JSON file")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted string JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(stringOption);
+        command.AddOption(publicKeyFileOption);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string str, string publicKeyFile, string outFile) =>
+        {
+            try
+            {
+                var keyJson = await File.ReadAllTextAsync(publicKeyFile);
+                var publicKey = JsonSerializer.Deserialize<PaillierPublicKey>(keyJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize public key.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var encrypted = component.EncryptString(str, publicKey);
+
+                await File.WriteAllTextAsync(outFile, JsonSerializer.Serialize(encrypted, JsonOptions));
+                Console.WriteLine($"Encrypted string ({encrypted.Characters.Length} characters) written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, stringOption, publicKeyFileOption, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateDecryptStringCommand()
+    {
+        var command = new Command("decrypt-string", "Decrypt a homomorphically encrypted string and print the plaintext");
+
+        var inFileOption = new Option<string>(
+            aliases: ["--in-file"],
+            description: "Path to the encrypted string JSON file")
+        {
+            IsRequired = true
+        };
+
+        var privateKeyFileOption = new Option<string>(
+            aliases: ["--private-key-file"],
+            description: "Path to the private key JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFileOption);
+        command.AddOption(privateKeyFileOption);
+
+        command.SetHandler(async (string inFile, string privateKeyFile) =>
+        {
+            try
+            {
+                var encJson = await File.ReadAllTextAsync(inFile);
+                var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
+
+                var keyJson = await File.ReadAllTextAsync(privateKeyFile);
+                var keyPair = JsonSerializer.Deserialize<PaillierKeyPair>(keyJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize private key.");
+
+                var component = new HomomorphicEncryptionComponent();
+                Console.WriteLine(component.DecryptString(encrypted, keyPair));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFileOption, privateKeyFileOption);
+
+        return command;
+    }
+
+    private static Command CreateReplaceCommand()
+    {
+        var command = new Command("replace", "Replace characters at a known position in an encrypted string without decrypting it");
+
+        var inFileOption = new Option<string>(
+            aliases: ["--in-file"],
+            description: "Path to the encrypted string JSON file")
+        {
+            IsRequired = true
+        };
+
+        var startOption = new Option<int>(
+            aliases: ["--start"],
+            description: "Zero-based index of the first character to replace")
+        {
+            IsRequired = true
+        };
+
+        var replacementOption = new Option<string>(
+            aliases: ["--replacement"],
+            description: "Plaintext replacement characters")
+        {
+            IsRequired = true
+        };
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the updated encrypted string JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFileOption);
+        command.AddOption(startOption);
+        command.AddOption(replacementOption);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string inFile, int start, string replacement, string outFile) =>
+        {
+            try
+            {
+                var encJson = await File.ReadAllTextAsync(inFile);
+                var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var updated = component.ReplaceInString(encrypted, start, replacement);
+
+                await File.WriteAllTextAsync(outFile, JsonSerializer.Serialize(updated, JsonOptions));
+                Console.WriteLine($"Updated encrypted string written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFileOption, startOption, replacementOption, outFileOption);
+
+        return command;
+    }
+
+    private static Command CreateSubstringCommand()
+    {
+        var command = new Command("substring", "Extract a slice of an encrypted string by position without decrypting it");
+
+        var inFileOption = new Option<string>(
+            aliases: ["--in-file"],
+            description: "Path to the encrypted string JSON file")
+        {
+            IsRequired = true
+        };
+
+        var startOption = new Option<int>(
+            aliases: ["--start"],
+            description: "Zero-based index of the first character to include")
+        {
+            IsRequired = true
+        };
+
+        var lengthOption = new Option<int?>(
+            aliases: ["--length"],
+            description: "Number of characters to include (defaults to remainder of string)");
+
+        var outFileOption = new Option<string>(
+            aliases: ["--out-file"],
+            description: "Path to write the encrypted substring JSON file")
+        {
+            IsRequired = true
+        };
+
+        command.AddOption(inFileOption);
+        command.AddOption(startOption);
+        command.AddOption(lengthOption);
+        command.AddOption(outFileOption);
+
+        command.SetHandler(async (string inFile, int start, int? length, string outFile) =>
+        {
+            try
+            {
+                var encJson = await File.ReadAllTextAsync(inFile);
+                var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
+                    ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
+
+                var component = new HomomorphicEncryptionComponent();
+                var substring = component.SubstringEncrypted(encrypted, start, length);
+
+                await File.WriteAllTextAsync(outFile, JsonSerializer.Serialize(substring, JsonOptions));
+                Console.WriteLine($"Encrypted substring ({substring.Characters.Length} characters) written to '{outFile}'");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }, inFileOption, startOption, lengthOption, outFileOption);
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
+++ b/Pixelbadger.Toolkit/Components/HomomorphicEncryptionComponent.cs
@@ -77,6 +77,95 @@ public class HomomorphicEncryptionComponent
         return L(x, n) * mu % n;
     }
 
+    public const int MaxStringLength = 100;
+
+    public EncryptedString EncryptString(string plaintext, PaillierPublicKey publicKey)
+    {
+        if (plaintext.Length > MaxStringLength)
+            throw new ArgumentException($"String must be at most {MaxStringLength} characters.", nameof(plaintext));
+
+        return new EncryptedString
+        {
+            Characters = plaintext.EnumerateRunes()
+                .Select(r => Encrypt(r.Value, publicKey))
+                .ToArray()
+        };
+    }
+
+    public string DecryptString(EncryptedString encryptedString, PaillierKeyPair key)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var encChar in encryptedString.Characters)
+            sb.Append(char.ConvertFromUtf32((int)Decrypt(encChar, key)));
+        return sb.ToString();
+    }
+
+    public EncryptedString SubstringEncrypted(EncryptedString encryptedString, int start, int? length = null)
+    {
+        var len = length ?? encryptedString.Characters.Length - start;
+
+        if (start < 0)
+            throw new ArgumentException("Start index must be non-negative.", nameof(start));
+        if (len < 0)
+            throw new ArgumentException("Length must be non-negative.", nameof(length));
+        if (start + len > encryptedString.Characters.Length)
+            throw new ArgumentException(
+                $"Range [{start}, {start + len}) exceeds string length {encryptedString.Characters.Length}.");
+
+        return new EncryptedString { Characters = encryptedString.Characters[start..(start + len)] };
+    }
+
+    public EncryptedString ReplaceInString(EncryptedString encryptedString, int start, string replacement)
+    {
+        var runes = replacement.EnumerateRunes().ToArray();
+
+        if (start < 0 || start + runes.Length > encryptedString.Characters.Length)
+            throw new ArgumentException(
+                $"Replacement range [{start}, {start + runes.Length}) exceeds string length {encryptedString.Characters.Length}.");
+
+        var publicKey = new PaillierPublicKey { N = encryptedString.Characters[0].N };
+        var newChars = (EncryptedNumber[])encryptedString.Characters.Clone();
+        for (var i = 0; i < runes.Length; i++)
+            newChars[start + i] = Encrypt(runes[i].Value, publicKey);
+
+        return new EncryptedString { Characters = newChars };
+    }
+
+    public EncryptedNumber MultiplyEncrypted(EncryptedNumber a, long scalar)
+    {
+        if (scalar < 0)
+            throw new ArgumentException("Scalar must be non-negative.", nameof(scalar));
+
+        var n = BigInteger.Parse(a.N);
+        ValidateModulus(n);
+        var nSquared = n * n;
+        var c = BigInteger.Parse(a.Ciphertext);
+
+        return new EncryptedNumber
+        {
+            Ciphertext = BigInteger.ModPow(c, new BigInteger(scalar), nSquared).ToString(),
+            N = a.N
+        };
+    }
+
+    public EncryptedNumber SubtractEncrypted(EncryptedNumber a, EncryptedNumber b)
+    {
+        if (a.N != b.N)
+            throw new ArgumentException("Both encrypted numbers must use the same public key (N).");
+
+        var n = BigInteger.Parse(a.N);
+        ValidateModulus(n);
+        var nSquared = n * n;
+        var ca = BigInteger.Parse(a.Ciphertext);
+        var cb = BigInteger.Parse(b.Ciphertext);
+
+        return new EncryptedNumber
+        {
+            Ciphertext = (ca * ModInverse(cb, nSquared) % nSquared).ToString(),
+            N = a.N
+        };
+    }
+
     public EncryptedNumber AddEncrypted(EncryptedNumber a, EncryptedNumber b)
     {
         if (a.N != b.N)

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;openai;crypto;homomorphic-encryption</PackageTags>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A CLI toolkit exposing varied functionality organized by topic, including string
   - [strings](#strings)
     - [reverse](#reverse)
     - [levenshtein-distance](#levenshtein-distance)
+    - [abjadify](#abjadify)
     - [flesch-reading-ease](#flesch-reading-ease)
   - [interpreters](#interpreters)
     - [brainfuck](#brainfuck)
@@ -34,6 +35,12 @@ A CLI toolkit exposing varied functionality organized by topic, including string
     - [encrypt](#encrypt)
     - [decrypt](#decrypt)
     - [add](#add)
+    - [subtract](#subtract)
+    - [multiply](#multiply)
+    - [encrypt-string](#encrypt-string)
+    - [decrypt-string](#decrypt-string)
+    - [replace](#replace)
+    - [substring](#substring)
 - [Help](#help)
 - [Requirements](#requirements)
 - [Technical Details](#technical-details)
@@ -115,6 +122,23 @@ pbtk strings levenshtein-distance --string1 "hello" --string2 "world"
 
 # Compare contents of two files
 pbtk strings levenshtein-distance --string1 file1.txt --string2 file2.txt
+```
+
+#### abjadify
+Strips English vowels from text while preserving single-vowel words (e.g. "a", "I").
+
+**Usage:**
+```bash
+pbtk strings abjadify --in-file <input-file> --out-file <output-file>
+```
+
+**Options:**
+- `--in-file`: Path to the input text file (required)
+- `--out-file`: Path to write the abjadified output file (required)
+
+**Example:**
+```bash
+pbtk strings abjadify --in-file article.txt --out-file article-abjad.txt
 ```
 
 #### flesch-reading-ease
@@ -529,6 +553,135 @@ pbtk crypto encrypt --number 5  --public-key-file my.pub --out-file b.enc
 pbtk crypto add --in-file1 a.enc --in-file2 b.enc --out-file sum.enc
 pbtk crypto decrypt --in-file sum.enc --private-key-file my.key
 # Output: 42
+```
+
+#### subtract
+Homomorphically subtracts one encrypted number from another without decrypting them. The result decrypts to the difference of the two original plaintexts. The minuend must be greater than or equal to the subtrahend.
+
+**Usage:**
+```bash
+pbtk crypto subtract --in-file1 <minuend-file> --in-file2 <subtrahend-file> --out-file <output-file>
+```
+
+**Options:**
+- `--in-file1`: Path to the first encrypted number JSON file (minuend) (required)
+- `--in-file2`: Path to the second encrypted number JSON file (subtrahend) (required)
+- `--out-file`: Path to write the encrypted difference JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt --number 100 --public-key-file my.pub --out-file a.enc
+pbtk crypto encrypt --number 58  --public-key-file my.pub --out-file b.enc
+pbtk crypto subtract --in-file1 a.enc --in-file2 b.enc --out-file diff.enc
+pbtk crypto decrypt --in-file diff.enc --private-key-file my.key
+# Output: 42
+```
+
+#### multiply
+Homomorphically multiplies an encrypted number by a plaintext scalar without decrypting it. The result decrypts to the product of the original plaintext and the scalar.
+
+**Usage:**
+```bash
+pbtk crypto multiply --in-file <encrypted-file> --scalar <scalar> --out-file <output-file>
+```
+
+**Options:**
+- `--in-file`: Path to the encrypted number JSON file (required)
+- `--scalar`: The non-negative plaintext integer to multiply by (required)
+- `--out-file`: Path to write the encrypted product JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt --number 7 --public-key-file my.pub --out-file a.enc
+pbtk crypto multiply --in-file a.enc --scalar 6 --out-file product.enc
+pbtk crypto decrypt --in-file product.enc --private-key-file my.key
+# Output: 42
+```
+
+#### encrypt-string
+Encrypts a UTF-8 string (up to 100 characters) as an array of independently homomorphically encrypted Unicode code points.
+
+**Usage:**
+```bash
+pbtk crypto encrypt-string --string <plaintext> --public-key-file <public-key-file> --out-file <output-file>
+```
+
+**Options:**
+- `--string`: The plaintext string to encrypt, max 100 characters (required)
+- `--public-key-file`: Path to the public key JSON file (required)
+- `--out-file`: Path to write the encrypted string JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt-string --string "hello world" --public-key-file my.pub --out-file msg.estr
+```
+
+#### decrypt-string
+Decrypts a homomorphically encrypted string and prints the plaintext.
+
+**Usage:**
+```bash
+pbtk crypto decrypt-string --in-file <encrypted-string-file> --private-key-file <private-key-file>
+```
+
+**Options:**
+- `--in-file`: Path to the encrypted string JSON file (required)
+- `--private-key-file`: Path to the private key JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto decrypt-string --in-file msg.estr --private-key-file my.key
+# Output: hello world
+```
+
+#### replace
+Replaces characters at a known position in an encrypted string without decrypting it. The replacement plaintext is re-encrypted; all other characters remain untouched.
+
+**Usage:**
+```bash
+pbtk crypto replace --in-file <encrypted-string-file> --start <index> --replacement <text> --out-file <output-file>
+```
+
+**Options:**
+- `--in-file`: Path to the encrypted string JSON file (required)
+- `--start`: Zero-based index of the first character to replace (required)
+- `--replacement`: Plaintext replacement characters (required)
+- `--out-file`: Path to write the updated encrypted string JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt-string --string "hello world" --public-key-file my.pub --out-file msg.estr
+pbtk crypto replace --in-file msg.estr --start 6 --replacement "there" --out-file updated.estr
+pbtk crypto decrypt-string --in-file updated.estr --private-key-file my.key
+# Output: hello there
+```
+
+#### substring
+Extracts a positional slice from an encrypted string without decrypting it. The result is a new encrypted string containing only the selected characters.
+
+**Usage:**
+```bash
+pbtk crypto substring --in-file <encrypted-string-file> --start <index> [--length <length>] --out-file <output-file>
+```
+
+**Options:**
+- `--in-file`: Path to the encrypted string JSON file (required)
+- `--start`: Zero-based index of the first character to include (required)
+- `--length`: Number of characters to include (optional, defaults to the remainder of the string)
+- `--out-file`: Path to write the encrypted substring JSON file (required)
+
+**Example:**
+```bash
+pbtk crypto encrypt-string --string "hello world" --public-key-file my.pub --out-file msg.estr
+
+# Extract "world" using start + length
+pbtk crypto substring --in-file msg.estr --start 6 --length 5 --out-file sub.estr
+
+# Extract "world" using start only (remainder of string)
+pbtk crypto substring --in-file msg.estr --start 6 --out-file sub.estr
+
+pbtk crypto decrypt-string --in-file sub.estr --private-key-file my.key
+# Output: world
 ```
 
 ## Help


### PR DESCRIPTION
## Summary
- Adds `pbtk crypto substring` command to extract a positional slice from an encrypted string without decrypting it
- `--length` is optional; omitting it returns from `--start` to the end of the string
- Adds `SubstringEncrypted` method to `HomomorphicEncryptionComponent` — purely structural array slice, no cryptographic computation

## Test plan
- [ ] 8 unit tests covering success paths, edge cases (zero length, single char, full string, no length), and 3 error conditions (negative start, negative length, out-of-range)
- [ ] 4 integration tests: happy path with length, omitted length, out-of-range error, missing input file

🤖 Generated with [Claude Code](https://claude.com/claude-code)