### PR TITLE
Add Claude-driven SDLC: kanban automation, release tagging, Haiku PR review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,18 +37,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Review this pull request against the following checklist only. Be concise — flag issues, don't praise. Post your findings as a single comment using `gh pr comment`.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            **1. Version bump** — If any `.cs` or `.csproj` files changed outside of `*.Tests/` or `*.Benchmarks/`, the `<Version>` element in `Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj` must be incremented. Flag if missing.
+
+            **2. Tests present** — Any new component class or command action must have a corresponding `*Tests.cs` file. Flag any new `Components/` or `Commands/` files without matching tests.
+
+            **3. Benchmarks updated** — If the diff touches `LevenshteinCalculator`, `BrainfuckInterpreter`, `OokInterpreter`, `AbjadifyComponent`, `ImageSteganography`, or `HomomorphicEncryptionComponent`, a corresponding benchmark file in `Pixelbadger.Toolkit.Benchmarks/` must also be updated. Flag if missing.
+
+            **4. Sanity check** — Flag obvious bugs, unhandled nulls in critical paths, prompt injection risks (user-controlled strings passed directly to LLMs), or path traversal in file operations.
+
+            If everything passes, post a brief "LGTM — all checks passed" comment.
+
+          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,32 +19,27 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # This is an optional setting that allows Claude to read CI results on PRs
+
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --allowed-tools "Bash(git checkout *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git branch *),Bash(git status),Bash(git diff *),Bash(git log *),Bash(gh issue list *),Bash(gh issue view *),Bash(gh issue edit *),Bash(gh issue close *),Bash(gh pr create *),Bash(gh pr view *),Bash(gh pr list *),Bash(gh pr merge *),Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr checks *),Bash(gh label create *),Bash(gh search *),Bash(dotnet build *),Bash(dotnet test *),Bash(dotnet run *)"
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,51 @@
+name: Project Automation
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Label and close linked issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(grep -oP '(?<=<Version>)[^<]+' Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj)
+          RELEASE_LABEL="release/v${VERSION}"
+
+          gh label create "$RELEASE_LABEL" \
+            --color "#6f42c1" \
+            --description "Released in v${VERSION}" \
+            2>/dev/null || true
+
+          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body')
+
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiP '(?:closes|fixes|resolves)\s+#\K\d+' || true)
+
+          if [ -z "$ISSUE_NUMBERS" ]; then
+            echo "No linked issues found in PR body."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            echo "Processing issue #${ISSUE_NUM}"
+            gh issue edit "$ISSUE_NUM" \
+              --add-label "$RELEASE_LABEL" \
+              --add-label "status: done" \
+              --remove-label "status: in-progress" \
+              2>/dev/null || true
+            gh issue close "$ISSUE_NUM" \
+              --comment "Closed by PR #${{ github.event.pull_request.number }}. Released in v${VERSION}." \
+              2>/dev/null || true
+          done

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-changes, build-and-test]
     if: needs.check-changes.outputs.main-code-changed == 'true'
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4
@@ -83,3 +85,18 @@ jobs:
           --skip-duplicate
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        VERSION=$(grep -oP '(?<=<Version>)[^<]+' Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj)
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag "v${VERSION}" || echo "Tag v${VERSION} already exists"
+        git push origin "v${VERSION}" || echo "Tag v${VERSION} already pushed"
+        gh release create "v${VERSION}" \
+          --title "Release v${VERSION}" \
+          --generate-notes \
+          --latest \
+          || echo "Release v${VERSION} already exists"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,53 @@ Available topics and actions:
 - **OPENAI_API_KEY**: Required for LLM functionality (openai, translate, ocaaar actions)
 - **NUGET_API_KEY**: Required for publishing packages to NuGet
 
+## Autonomous Ticket Workflow
+
+When asked to "work on the next ticket" (via `@claude` mention on a GitHub issue or PR comment), follow these steps:
+
+### GitHub Label Conventions
+- `status: to-do` — issue is ready to work on
+- `status: in-progress` — issue is being implemented
+- `status: done` — issue is complete (applied automatically on merge)
+- `release/vX.Y.Z` — applied automatically on merge to identify which release closed the issue
+
+### Steps
+
+1. **Find the next ticket**
+   ```bash
+   gh issue list --label "status: to-do" --state open --limit 1 --json number,title,body
+   ```
+
+2. **Claim it** (move to in-progress)
+   ```bash
+   gh issue edit <N> --remove-label "status: to-do" --add-label "status: in-progress"
+   ```
+
+3. **Implement** — follow the Feature Branch Process above. Branch name: `feature/<short-description>`
+
+4. **Raise a PR** — the body must link the issue so project automation can close it on merge:
+   ```bash
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   Closes #<N>
+
+   ## Summary
+   <what changed and why>
+
+   ## Test plan
+   - [ ] Tests pass: `dotnet test`
+   - [ ] Version bumped in csproj
+   EOF
+   )"
+   ```
+
+5. **Iterate on review** — address all comments from the automated Haiku review and any `@claude` follow-up comments, then push new commits to the branch.
+
+6. **Merge when approved** — once CI passes and the PR is approved:
+   ```bash
+   gh pr merge <PR-number> --squash --delete-branch
+   ```
+   The `project-automation` workflow will automatically apply the release label and close the linked issue.
+
 ## Important Instructions
 
 Do what has been asked; nothing more, nothing less.


### PR DESCRIPTION
## Summary
- **Haiku PR review**: `claude-code-review.yml` now uses `claude-haiku-4-5-20251001` with a focused 4-point checklist (version bump present, tests present for new code, benchmarks updated for compute-heavy components, security sanity check). Faster and cheaper than broad analysis.
- **Automatic GitHub Releases**: `publish-to-nuget.yml` creates a `vX.Y.Z` git tag and GitHub Release after each successful NuGet publish, with auto-generated release notes.
- **Project automation** (`project-automation.yml`, new): on any PR merge to master, reads the version from the csproj, creates a `release/vX.Y.Z` label, and applies it to all issues linked via `Closes/Fixes/Resolves #N` in the PR body — then closes those issues.
- **Autonomous Claude workflow**: `claude.yml` now has `contents/pull-requests/issues: write` permissions and an expanded `--allowed-tools` list covering git, gh, and dotnet commands, so Claude can implement a full ticket end-to-end when asked.
- **CLAUDE.md**: new "Autonomous Ticket Workflow" section documents the label conventions (`status: to-do`, `status: in-progress`, `status: done`) and the step-by-step flow for autonomous ticket work.

## One-time manual setup required after merge
```bash
# Create the status labels on the repo
gh label create "status: to-do"       --color "#0075ca" --description "Ready to work on"
gh label create "status: in-progress" --color "#e4e669" --description "Being worked on"
gh label create "status: done"        --color "#0e8a16" --description "Completed"

# Create the GitHub Projects board
# https://github.com/pixelbadger/Pixelbadger.Toolkit/projects → New project → Board
# Columns: To Do | In Progress | Done
# Enable native automation: "Item closed → move to Done"
```

## Test plan
- [ ] Open a PR with a code change → Haiku review posts a focused checklist comment
- [ ] Merge a code-change PR to master → NuGet publishes, git tag created, GitHub Release appears
- [ ] Merge a PR with `Closes #N` in body → issue gets `release/vX.Y.Z` label and is closed
- [ ] Comment `@claude work on the next ticket` on an issue labeled `status: to-do` → Claude creates a branch, implements, opens a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)