### PR TITLE
Update NuGet packages

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     
@@ -37,7 +37,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Review this pull request against the following checklist only. Be concise — flag issues, don't praise. Post your findings as a single comment using `gh pr comment`.
+            Review this pull request against the following checklist only. Be concise — flag issues, don't praise.
 
             **1. Version bump** — If any `.cs` or `.csproj` files changed outside of `*.Tests/` or `*.Benchmarks/`, the `<Version>` element in `Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj` must be incremented. Flag if missing.
 
@@ -47,7 +47,9 @@ jobs:
 
             **4. Sanity check** — Flag obvious bugs, unhandled nulls in critical paths, prompt injection risks (user-controlled strings passed directly to LLMs), or path traversal in file operations.
 
-            If everything passes, post a brief "LGTM — all checks passed" comment.
+            Once you have completed the review, submit a formal GitHub review using `gh pr review`:
+            - If all checks pass: `gh pr review <PR_NUMBER> --approve --body "LGTM — all checks passed."`
+            - If any check fails: `gh pr review <PR_NUMBER> --request-changes --body "<summary of issues found>"`
 
-          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"'
 

--- a/Pixelbadger.Toolkit.Tests/Pixelbadger.Toolkit.Tests.csproj
+++ b/Pixelbadger.Toolkit.Tests/Pixelbadger.Toolkit.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="8.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="OpenAI" Version="2.4.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/CryptoCommand.cs
@@ -13,16 +13,16 @@ public static class CryptoCommand
     {
         var command = new Command("crypto", "Homomorphic encryption utilities using the Paillier cryptosystem");
 
-        command.AddCommand(CreateGenerateKeyCommand());
-        command.AddCommand(CreateEncryptCommand());
-        command.AddCommand(CreateDecryptCommand());
-        command.AddCommand(CreateAddCommand());
-        command.AddCommand(CreateSubtractCommand());
-        command.AddCommand(CreateMultiplyCommand());
-        command.AddCommand(CreateEncryptStringCommand());
-        command.AddCommand(CreateDecryptStringCommand());
-        command.AddCommand(CreateReplaceCommand());
-        command.AddCommand(CreateSubstringCommand());
+        command.Add(CreateGenerateKeyCommand());
+        command.Add(CreateEncryptCommand());
+        command.Add(CreateDecryptCommand());
+        command.Add(CreateAddCommand());
+        command.Add(CreateSubtractCommand());
+        command.Add(CreateMultiplyCommand());
+        command.Add(CreateEncryptStringCommand());
+        command.Add(CreateDecryptStringCommand());
+        command.Add(CreateReplaceCommand());
+        command.Add(CreateSubstringCommand());
 
         return command;
     }
@@ -31,27 +31,19 @@ public static class CryptoCommand
     {
         var command = new Command("generate-key", "Generate a Paillier key pair and save public and private key files");
 
-        var publicKeyFileOption = new Option<string>(
-            aliases: ["--public-key-file"],
-            description: "Path to write the public key JSON file (contains N; safe to share)")
-        {
-            IsRequired = true
-        };
+        var publicKeyFileOption = new Option<string>("--public-key-file") { Description = "Path to write the public key JSON file (contains N; safe to share)", Required = true };
+        var privateKeyFileOption = new Option<string>("--private-key-file") { Description = "Path to write the private key JSON file (contains N, Lambda, Mu; keep secret)", Required = true };
 
-        var privateKeyFileOption = new Option<string>(
-            aliases: ["--private-key-file"],
-            description: "Path to write the private key JSON file (contains N, Lambda, Mu; keep secret)")
-        {
-            IsRequired = true
-        };
+        command.Add(publicKeyFileOption);
+        command.Add(privateKeyFileOption);
 
-        command.AddOption(publicKeyFileOption);
-        command.AddOption(privateKeyFileOption);
-
-        command.SetHandler(async (string publicKeyFile, string privateKeyFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var publicKeyFile = parseResult.GetValue(publicKeyFileOption)!;
+                var privateKeyFile = parseResult.GetValue(privateKeyFileOption)!;
+
                 var component = new HomomorphicEncryptionComponent();
                 var keyPair = component.GenerateKey();
                 var publicKey = new PaillierPublicKey { N = keyPair.N };
@@ -67,7 +59,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, publicKeyFileOption, privateKeyFileOption);
+        });
 
         return command;
     }
@@ -76,35 +68,22 @@ public static class CryptoCommand
     {
         var command = new Command("encrypt", "Encrypt a number using a Paillier public key");
 
-        var numberOption = new Option<long>(
-            aliases: ["--number"],
-            description: "The non-negative integer to encrypt")
-        {
-            IsRequired = true
-        };
+        var numberOption = new Option<long>("--number") { Description = "The non-negative integer to encrypt", Required = true };
+        var publicKeyFileOption = new Option<string>("--public-key-file") { Description = "Path to the public key JSON file", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted number JSON file", Required = true };
 
-        var publicKeyFileOption = new Option<string>(
-            aliases: ["--public-key-file"],
-            description: "Path to the public key JSON file")
-        {
-            IsRequired = true
-        };
+        command.Add(numberOption);
+        command.Add(publicKeyFileOption);
+        command.Add(outFileOption);
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted number JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(numberOption);
-        command.AddOption(publicKeyFileOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (long number, string publicKeyFile, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var number = parseResult.GetValue(numberOption);
+                var publicKeyFile = parseResult.GetValue(publicKeyFileOption)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var keyJson = await File.ReadAllTextAsync(publicKeyFile);
                 var publicKey = JsonSerializer.Deserialize<PaillierPublicKey>(keyJson)
                     ?? throw new InvalidOperationException("Failed to deserialize public key.");
@@ -121,7 +100,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, numberOption, publicKeyFileOption, outFileOption);
+        });
 
         return command;
     }
@@ -130,27 +109,19 @@ public static class CryptoCommand
     {
         var command = new Command("decrypt", "Decrypt an encrypted number using a Paillier private key");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Path to the encrypted number JSON file")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Path to the encrypted number JSON file", Required = true };
+        var privateKeyFileOption = new Option<string>("--private-key-file") { Description = "Path to the private key JSON file", Required = true };
 
-        var privateKeyFileOption = new Option<string>(
-            aliases: ["--private-key-file"],
-            description: "Path to the private key JSON file")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(privateKeyFileOption);
 
-        command.AddOption(inFileOption);
-        command.AddOption(privateKeyFileOption);
-
-        command.SetHandler(async (string inFile, string privateKeyFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var privateKeyFile = parseResult.GetValue(privateKeyFileOption)!;
+
                 var encryptedJson = await File.ReadAllTextAsync(inFile);
                 var encrypted = JsonSerializer.Deserialize<EncryptedNumber>(encryptedJson)
                     ?? throw new InvalidOperationException("Failed to deserialize encrypted number.");
@@ -168,7 +139,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, privateKeyFileOption);
+        });
 
         return command;
     }
@@ -177,35 +148,22 @@ public static class CryptoCommand
     {
         var command = new Command("add", "Homomorphically add two encrypted numbers without decrypting them");
 
-        var inFile1Option = new Option<string>(
-            aliases: ["--in-file1"],
-            description: "Path to the first encrypted number JSON file")
-        {
-            IsRequired = true
-        };
+        var inFile1Option = new Option<string>("--in-file1") { Description = "Path to the first encrypted number JSON file", Required = true };
+        var inFile2Option = new Option<string>("--in-file2") { Description = "Path to the second encrypted number JSON file", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted sum JSON file", Required = true };
 
-        var inFile2Option = new Option<string>(
-            aliases: ["--in-file2"],
-            description: "Path to the second encrypted number JSON file")
-        {
-            IsRequired = true
-        };
+        command.Add(inFile1Option);
+        command.Add(inFile2Option);
+        command.Add(outFileOption);
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted sum JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(inFile1Option);
-        command.AddOption(inFile2Option);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile1, string inFile2, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile1 = parseResult.GetValue(inFile1Option)!;
+                var inFile2 = parseResult.GetValue(inFile2Option)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var enc1Json = await File.ReadAllTextAsync(inFile1);
                 var encrypted1 = JsonSerializer.Deserialize<EncryptedNumber>(enc1Json)
                     ?? throw new InvalidOperationException("Failed to deserialize first encrypted number.");
@@ -226,7 +184,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFile1Option, inFile2Option, outFileOption);
+        });
 
         return command;
     }
@@ -235,35 +193,22 @@ public static class CryptoCommand
     {
         var command = new Command("subtract", "Homomorphically subtract two encrypted numbers without decrypting them");
 
-        var inFile1Option = new Option<string>(
-            aliases: ["--in-file1"],
-            description: "Path to the first encrypted number JSON file (minuend)")
-        {
-            IsRequired = true
-        };
+        var inFile1Option = new Option<string>("--in-file1") { Description = "Path to the first encrypted number JSON file (minuend)", Required = true };
+        var inFile2Option = new Option<string>("--in-file2") { Description = "Path to the second encrypted number JSON file (subtrahend)", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted difference JSON file", Required = true };
 
-        var inFile2Option = new Option<string>(
-            aliases: ["--in-file2"],
-            description: "Path to the second encrypted number JSON file (subtrahend)")
-        {
-            IsRequired = true
-        };
+        command.Add(inFile1Option);
+        command.Add(inFile2Option);
+        command.Add(outFileOption);
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted difference JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(inFile1Option);
-        command.AddOption(inFile2Option);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile1, string inFile2, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile1 = parseResult.GetValue(inFile1Option)!;
+                var inFile2 = parseResult.GetValue(inFile2Option)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var enc1Json = await File.ReadAllTextAsync(inFile1);
                 var encrypted1 = JsonSerializer.Deserialize<EncryptedNumber>(enc1Json)
                     ?? throw new InvalidOperationException("Failed to deserialize first encrypted number.");
@@ -284,7 +229,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFile1Option, inFile2Option, outFileOption);
+        });
 
         return command;
     }
@@ -293,35 +238,22 @@ public static class CryptoCommand
     {
         var command = new Command("multiply", "Homomorphically multiply an encrypted number by a plaintext scalar without decrypting it");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Path to the encrypted number JSON file")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Path to the encrypted number JSON file", Required = true };
+        var scalarOption = new Option<long>("--scalar") { Description = "The non-negative plaintext integer to multiply by", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted product JSON file", Required = true };
 
-        var scalarOption = new Option<long>(
-            aliases: ["--scalar"],
-            description: "The non-negative plaintext integer to multiply by")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(scalarOption);
+        command.Add(outFileOption);
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted product JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(inFileOption);
-        command.AddOption(scalarOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile, long scalar, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var scalar = parseResult.GetValue(scalarOption);
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var encJson = await File.ReadAllTextAsync(inFile);
                 var encrypted = JsonSerializer.Deserialize<EncryptedNumber>(encJson)
                     ?? throw new InvalidOperationException("Failed to deserialize encrypted number.");
@@ -338,7 +270,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, scalarOption, outFileOption);
+        });
 
         return command;
     }
@@ -347,35 +279,22 @@ public static class CryptoCommand
     {
         var command = new Command("encrypt-string", "Encrypt a UTF-8 string (max 100 characters) as an array of homomorphically encrypted code points");
 
-        var stringOption = new Option<string>(
-            aliases: ["--string"],
-            description: "The plaintext string to encrypt (max 100 characters)")
-        {
-            IsRequired = true
-        };
+        var stringOption = new Option<string>("--string") { Description = "The plaintext string to encrypt (max 100 characters)", Required = true };
+        var publicKeyFileOption = new Option<string>("--public-key-file") { Description = "Path to the public key JSON file", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted string JSON file", Required = true };
 
-        var publicKeyFileOption = new Option<string>(
-            aliases: ["--public-key-file"],
-            description: "Path to the public key JSON file")
-        {
-            IsRequired = true
-        };
+        command.Add(stringOption);
+        command.Add(publicKeyFileOption);
+        command.Add(outFileOption);
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted string JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(stringOption);
-        command.AddOption(publicKeyFileOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string str, string publicKeyFile, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var str = parseResult.GetValue(stringOption)!;
+                var publicKeyFile = parseResult.GetValue(publicKeyFileOption)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var keyJson = await File.ReadAllTextAsync(publicKeyFile);
                 var publicKey = JsonSerializer.Deserialize<PaillierPublicKey>(keyJson)
                     ?? throw new InvalidOperationException("Failed to deserialize public key.");
@@ -391,7 +310,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, stringOption, publicKeyFileOption, outFileOption);
+        });
 
         return command;
     }
@@ -400,27 +319,19 @@ public static class CryptoCommand
     {
         var command = new Command("decrypt-string", "Decrypt a homomorphically encrypted string and print the plaintext");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Path to the encrypted string JSON file")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Path to the encrypted string JSON file", Required = true };
+        var privateKeyFileOption = new Option<string>("--private-key-file") { Description = "Path to the private key JSON file", Required = true };
 
-        var privateKeyFileOption = new Option<string>(
-            aliases: ["--private-key-file"],
-            description: "Path to the private key JSON file")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(privateKeyFileOption);
 
-        command.AddOption(inFileOption);
-        command.AddOption(privateKeyFileOption);
-
-        command.SetHandler(async (string inFile, string privateKeyFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var privateKeyFile = parseResult.GetValue(privateKeyFileOption)!;
+
                 var encJson = await File.ReadAllTextAsync(inFile);
                 var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
                     ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
@@ -437,7 +348,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, privateKeyFileOption);
+        });
 
         return command;
     }
@@ -446,43 +357,25 @@ public static class CryptoCommand
     {
         var command = new Command("replace", "Replace characters at a known position in an encrypted string without decrypting it");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Path to the encrypted string JSON file")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Path to the encrypted string JSON file", Required = true };
+        var startOption = new Option<int>("--start") { Description = "Zero-based index of the first character to replace", Required = true };
+        var replacementOption = new Option<string>("--replacement") { Description = "Plaintext replacement characters", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the updated encrypted string JSON file", Required = true };
 
-        var startOption = new Option<int>(
-            aliases: ["--start"],
-            description: "Zero-based index of the first character to replace")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(startOption);
+        command.Add(replacementOption);
+        command.Add(outFileOption);
 
-        var replacementOption = new Option<string>(
-            aliases: ["--replacement"],
-            description: "Plaintext replacement characters")
-        {
-            IsRequired = true
-        };
-
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the updated encrypted string JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(inFileOption);
-        command.AddOption(startOption);
-        command.AddOption(replacementOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile, int start, string replacement, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var start = parseResult.GetValue(startOption);
+                var replacement = parseResult.GetValue(replacementOption)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var encJson = await File.ReadAllTextAsync(inFile);
                 var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
                     ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
@@ -498,7 +391,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, startOption, replacementOption, outFileOption);
+        });
 
         return command;
     }
@@ -507,40 +400,25 @@ public static class CryptoCommand
     {
         var command = new Command("substring", "Extract a slice of an encrypted string by position without decrypting it");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Path to the encrypted string JSON file")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Path to the encrypted string JSON file", Required = true };
+        var startOption = new Option<int>("--start") { Description = "Zero-based index of the first character to include", Required = true };
+        var lengthOption = new Option<int?>("--length") { Description = "Number of characters to include (defaults to remainder of string)" };
+        var outFileOption = new Option<string>("--out-file") { Description = "Path to write the encrypted substring JSON file", Required = true };
 
-        var startOption = new Option<int>(
-            aliases: ["--start"],
-            description: "Zero-based index of the first character to include")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(startOption);
+        command.Add(lengthOption);
+        command.Add(outFileOption);
 
-        var lengthOption = new Option<int?>(
-            aliases: ["--length"],
-            description: "Number of characters to include (defaults to remainder of string)");
-
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Path to write the encrypted substring JSON file")
-        {
-            IsRequired = true
-        };
-
-        command.AddOption(inFileOption);
-        command.AddOption(startOption);
-        command.AddOption(lengthOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile, int start, int? length, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var start = parseResult.GetValue(startOption);
+                var length = parseResult.GetValue(lengthOption);
+                var outFile = parseResult.GetValue(outFileOption)!;
+
                 var encJson = await File.ReadAllTextAsync(inFile);
                 var encrypted = JsonSerializer.Deserialize<EncryptedString>(encJson)
                     ?? throw new InvalidOperationException("Failed to deserialize encrypted string.");
@@ -556,7 +434,7 @@ public static class CryptoCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, startOption, lengthOption, outFileOption);
+        });
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Commands/ImagesCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/ImagesCommand.cs
@@ -9,7 +9,7 @@ public static class ImagesCommand
     {
         var command = new Command("images", "Image processing and manipulation utilities");
 
-        command.AddCommand(CreateSteganographyCommand());
+        command.Add(CreateSteganographyCommand());
 
         return command;
     }
@@ -18,43 +18,24 @@ public static class ImagesCommand
     {
         var command = new Command("steganography", "Encode or decode hidden messages in images using LSB steganography");
 
-        var modeOption = new Option<string>(
-            aliases: ["--mode"],
-            description: "Operation mode: 'encode' or 'decode'")
-        {
-            IsRequired = true
-        };
+        var modeOption = new Option<string>("--mode") { Description = "Operation mode: 'encode' or 'decode'", Required = true };
+        var imageOption = new Option<string>("--image") { Description = "Input image file path", Required = true };
+        var messageOption = new Option<string?>("--message") { Description = "Message to encode (required for encode mode)" };
+        var outputOption = new Option<string?>("--output") { Description = "Output image file path (required for encode mode)" };
 
-        var imageOption = new Option<string>(
-            aliases: ["--image"],
-            description: "Input image file path")
-        {
-            IsRequired = true
-        };
+        command.Add(modeOption);
+        command.Add(imageOption);
+        command.Add(messageOption);
+        command.Add(outputOption);
 
-        var messageOption = new Option<string?>(
-            aliases: ["--message"],
-            description: "Message to encode (required for encode mode)")
-        {
-            IsRequired = false
-        };
-
-        var outputOption = new Option<string?>(
-            aliases: ["--output"],
-            description: "Output image file path (required for encode mode)")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(modeOption);
-        command.AddOption(imageOption);
-        command.AddOption(messageOption);
-        command.AddOption(outputOption);
-
-        command.SetHandler(async (string mode, string image, string? message, string? output) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var mode = parseResult.GetValue(modeOption)!;
+                var image = parseResult.GetValue(imageOption)!;
+                var message = parseResult.GetValue(messageOption);
+                var output = parseResult.GetValue(outputOption);
                 var steganography = new ImageSteganography();
 
                 if (mode.ToLower() == "encode")
@@ -92,9 +73,8 @@ public static class ImagesCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, modeOption, imageOption, messageOption, outputOption);
+        });
 
         return command;
     }
-
 }

--- a/Pixelbadger.Toolkit/Commands/InterpretersCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/InterpretersCommand.cs
@@ -9,9 +9,9 @@ public static class InterpretersCommand
     {
         var command = new Command("interpreters", "Esoteric programming language interpreters");
 
-        command.AddCommand(CreateBrainfuckCommand());
-        command.AddCommand(CreateOokCommand());
-        command.AddCommand(CreateBfToOokCommand());
+        command.Add(CreateBrainfuckCommand());
+        command.Add(CreateOokCommand());
+        command.Add(CreateBfToOokCommand());
 
         return command;
     }
@@ -20,19 +20,15 @@ public static class InterpretersCommand
     {
         var command = new Command("brainfuck", "Executes a Brainfuck program from a file");
 
-        var fileOption = new Option<string>(
-            aliases: ["--file"],
-            description: "Path to the Brainfuck program file")
-        {
-            IsRequired = true
-        };
+        var fileOption = new Option<string>("--file") { Description = "Path to the Brainfuck program file", Required = true };
 
-        command.AddOption(fileOption);
+        command.Add(fileOption);
 
-        command.SetHandler(async (string file) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var file = parseResult.GetValue(fileOption)!;
                 var interpreter = new BrainfuckInterpreter();
                 var result = await interpreter.ExecuteAsync(file);
                 Console.Write(result);
@@ -42,7 +38,7 @@ public static class InterpretersCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, fileOption);
+        });
 
         return command;
     }
@@ -51,19 +47,15 @@ public static class InterpretersCommand
     {
         var command = new Command("ook", "Executes an Ook program from a file");
 
-        var fileOption = new Option<string>(
-            aliases: ["--file"],
-            description: "Path to the Ook program file")
-        {
-            IsRequired = true
-        };
+        var fileOption = new Option<string>("--file") { Description = "Path to the Ook program file", Required = true };
 
-        command.AddOption(fileOption);
+        command.Add(fileOption);
 
-        command.SetHandler(async (string file) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var file = parseResult.GetValue(fileOption)!;
                 var interpreter = new OokInterpreter();
                 var result = await interpreter.ExecuteAsync(file);
                 Console.Write(result);
@@ -73,7 +65,7 @@ public static class InterpretersCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, fileOption);
+        });
 
         return command;
     }
@@ -82,27 +74,18 @@ public static class InterpretersCommand
     {
         var command = new Command("bf-to-ook", "Converts a Brainfuck program to Ook language");
 
-        var sourceOption = new Option<string>(
-            aliases: ["--source"],
-            description: "Path to the source Brainfuck program file")
-        {
-            IsRequired = true
-        };
+        var sourceOption = new Option<string>("--source") { Description = "Path to the source Brainfuck program file", Required = true };
+        var outputOption = new Option<string>("--output") { Description = "Path to the output Ook program file", Required = true };
 
-        var outputOption = new Option<string>(
-            aliases: ["--output"],
-            description: "Path to the output Ook program file")
-        {
-            IsRequired = true
-        };
+        command.Add(sourceOption);
+        command.Add(outputOption);
 
-        command.AddOption(sourceOption);
-        command.AddOption(outputOption);
-
-        command.SetHandler(async (string source, string output) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var source = parseResult.GetValue(sourceOption)!;
+                var output = parseResult.GetValue(outputOption)!;
                 var component = new BfToOokComponent();
                 await component.TranslateFileAsync(source, output);
                 Console.WriteLine($"Successfully converted {source} to Ook language and saved to {output}");
@@ -112,9 +95,8 @@ public static class InterpretersCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, sourceOption, outputOption);
+        });
 
         return command;
     }
-
 }

--- a/Pixelbadger.Toolkit/Commands/OAuthCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/OAuthCommand.cs
@@ -10,8 +10,8 @@ public static class OAuthCommand
     {
         var command = new Command("oauth", "OAuth utilities for managing profiles and acquiring tokens");
 
-        command.AddCommand(CreateTokenCommand());
-        command.AddCommand(CreateProfileCommand());
+        command.Add(CreateTokenCommand());
+        command.Add(CreateProfileCommand());
 
         return command;
     }
@@ -20,19 +20,15 @@ public static class OAuthCommand
     {
         var command = new Command("token", "Acquire an OAuth access token using Resource Owner Password Credentials");
 
-        var profileOption = new Option<string>(
-            aliases: ["--profile"],
-            description: "Name of the OAuth profile to use")
-        {
-            IsRequired = true
-        };
+        var profileOption = new Option<string>("--profile") { Description = "Name of the OAuth profile to use", Required = true };
 
-        command.AddOption(profileOption);
+        command.Add(profileOption);
 
-        command.SetHandler(async (string profile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var profile = parseResult.GetValue(profileOption)!;
                 Console.Write("Username: ");
                 var username = Console.ReadLine() ?? string.Empty;
 
@@ -50,7 +46,7 @@ public static class OAuthCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, profileOption);
+        });
 
         return command;
     }
@@ -59,9 +55,9 @@ public static class OAuthCommand
     {
         var command = new Command("profile", "Manage OAuth profiles");
 
-        command.AddCommand(CreateProfileAddCommand());
-        command.AddCommand(CreateProfileUpdateCommand());
-        command.AddCommand(CreateProfileDeleteCommand());
+        command.Add(CreateProfileAddCommand());
+        command.Add(CreateProfileUpdateCommand());
+        command.Add(CreateProfileDeleteCommand());
 
         return command;
     }
@@ -70,51 +66,28 @@ public static class OAuthCommand
     {
         var command = new Command("add", "Add a new OAuth profile");
 
-        var nameOption = new Option<string>(
-            aliases: ["--name"],
-            description: "Profile name")
-        {
-            IsRequired = true
-        };
+        var nameOption = new Option<string>("--name") { Description = "Profile name", Required = true };
+        var authorityOption = new Option<string>("--authority") { Description = "OAuth authority URI (e.g. https://login.microsoftonline.com/tenant)", Required = true };
+        var clientIdOption = new Option<string>("--client-id") { Description = "OAuth client ID", Required = true };
+        var clientSecretOption = new Option<string?>("--client-secret") { Description = "OAuth client secret (will be prompted securely if omitted)" };
+        var scopeOption = new Option<string?>("--scope") { Description = "OAuth scope (optional)" };
 
-        var authorityOption = new Option<string>(
-            aliases: ["--authority"],
-            description: "OAuth authority URI (e.g. https://login.microsoftonline.com/tenant)")
-        {
-            IsRequired = true
-        };
+        command.Add(nameOption);
+        command.Add(authorityOption);
+        command.Add(clientIdOption);
+        command.Add(clientSecretOption);
+        command.Add(scopeOption);
 
-        var clientIdOption = new Option<string>(
-            aliases: ["--client-id"],
-            description: "OAuth client ID")
-        {
-            IsRequired = true
-        };
-
-        var clientSecretOption = new Option<string?>(
-            aliases: ["--client-secret"],
-            description: "OAuth client secret (will be prompted securely if omitted)")
-        {
-            IsRequired = false
-        };
-
-        var scopeOption = new Option<string?>(
-            aliases: ["--scope"],
-            description: "OAuth scope (optional)")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(nameOption);
-        command.AddOption(authorityOption);
-        command.AddOption(clientIdOption);
-        command.AddOption(clientSecretOption);
-        command.AddOption(scopeOption);
-
-        command.SetHandler(async (string name, string authority, string clientId, string? clientSecret, string? scope) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var name = parseResult.GetValue(nameOption)!;
+                var authority = parseResult.GetValue(authorityOption)!;
+                var clientId = parseResult.GetValue(clientIdOption)!;
+                var clientSecret = parseResult.GetValue(clientSecretOption);
+                var scope = parseResult.GetValue(scopeOption);
+
                 if (clientSecret is null)
                     clientSecret = ReadSecureInput("Client Secret (leave blank if none): ");
 
@@ -129,7 +102,7 @@ public static class OAuthCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, nameOption, authorityOption, clientIdOption, clientSecretOption, scopeOption);
+        });
 
         return command;
     }
@@ -138,51 +111,28 @@ public static class OAuthCommand
     {
         var command = new Command("update", "Update an existing OAuth profile");
 
-        var nameOption = new Option<string>(
-            aliases: ["--name"],
-            description: "Profile name to update")
-        {
-            IsRequired = true
-        };
+        var nameOption = new Option<string>("--name") { Description = "Profile name to update", Required = true };
+        var authorityOption = new Option<string?>("--authority") { Description = "New OAuth authority URI" };
+        var clientIdOption = new Option<string?>("--client-id") { Description = "New OAuth client ID" };
+        var clientSecretOption = new Option<string?>("--client-secret") { Description = "New OAuth client secret (will be prompted securely if omitted)" };
+        var scopeOption = new Option<string?>("--scope") { Description = "New OAuth scope" };
 
-        var authorityOption = new Option<string?>(
-            aliases: ["--authority"],
-            description: "New OAuth authority URI")
-        {
-            IsRequired = false
-        };
+        command.Add(nameOption);
+        command.Add(authorityOption);
+        command.Add(clientIdOption);
+        command.Add(clientSecretOption);
+        command.Add(scopeOption);
 
-        var clientIdOption = new Option<string?>(
-            aliases: ["--client-id"],
-            description: "New OAuth client ID")
-        {
-            IsRequired = false
-        };
-
-        var clientSecretOption = new Option<string?>(
-            aliases: ["--client-secret"],
-            description: "New OAuth client secret (will be prompted securely if omitted)")
-        {
-            IsRequired = false
-        };
-
-        var scopeOption = new Option<string?>(
-            aliases: ["--scope"],
-            description: "New OAuth scope")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(nameOption);
-        command.AddOption(authorityOption);
-        command.AddOption(clientIdOption);
-        command.AddOption(clientSecretOption);
-        command.AddOption(scopeOption);
-
-        command.SetHandler(async (string name, string? authority, string? clientId, string? clientSecret, string? scope) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var name = parseResult.GetValue(nameOption)!;
+                var authority = parseResult.GetValue(authorityOption);
+                var clientId = parseResult.GetValue(clientIdOption);
+                var clientSecret = parseResult.GetValue(clientSecretOption);
+                var scope = parseResult.GetValue(scopeOption);
+
                 var profileService = new OAuthProfileService();
                 var profileComponent = new OAuthProfileComponent(profileService);
                 await profileComponent.UpdateProfileAsync(name, authority, clientId, clientSecret, scope);
@@ -194,7 +144,7 @@ public static class OAuthCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, nameOption, authorityOption, clientIdOption, clientSecretOption, scopeOption);
+        });
 
         return command;
     }
@@ -203,19 +153,15 @@ public static class OAuthCommand
     {
         var command = new Command("delete", "Delete an OAuth profile");
 
-        var nameOption = new Option<string>(
-            aliases: ["--name"],
-            description: "Profile name to delete")
-        {
-            IsRequired = true
-        };
+        var nameOption = new Option<string>("--name") { Description = "Profile name to delete", Required = true };
 
-        command.AddOption(nameOption);
+        command.Add(nameOption);
 
-        command.SetHandler(async (string name) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var name = parseResult.GetValue(nameOption)!;
                 var profileService = new OAuthProfileService();
                 var profileComponent = new OAuthProfileComponent(profileService);
                 await profileComponent.DeleteProfileAsync(name);
@@ -227,7 +173,7 @@ public static class OAuthCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, nameOption);
+        });
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Commands/OpenAiCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/OpenAiCommand.cs
@@ -10,10 +10,10 @@ public static class OpenAiCommand
     {
         var command = new Command("openai", "OpenAI utilities");
 
-        command.AddCommand(CreateChatCommand());
-        command.AddCommand(CreateTranslateCommand());
-        command.AddCommand(CreateOcaaarCommand());
-        command.AddCommand(CreateCorpospeakCommand());
+        command.Add(CreateChatCommand());
+        command.Add(CreateTranslateCommand());
+        command.Add(CreateOcaaarCommand());
+        command.Add(CreateCorpospeakCommand());
 
         return command;
     }
@@ -22,36 +22,22 @@ public static class OpenAiCommand
     {
         var command = new Command("chat", "Chat with OpenAI maintaining conversation history");
 
-        var messageOption = new Option<string>(
-            aliases: ["--message"],
-            description: "The message to send to the LLM")
-        {
-            IsRequired = true
-        };
+        var messageOption = new Option<string>("--message") { Description = "The message to send to the LLM", Required = true };
+        var chatHistoryOption = new Option<string?>("--chat-history") { Description = "Path to JSON file containing chat history (will be created if it doesn't exist)" };
+        var modelOption = new Option<string>("--model") { Description = "The OpenAI model to use", DefaultValueFactory = _ => "gpt-5-nano" };
 
-        var chatHistoryOption = new Option<string?>(
-            aliases: ["--chat-history"],
-            description: "Path to JSON file containing chat history (will be created if it doesn't exist)")
-        {
-            IsRequired = false
-        };
+        command.Add(messageOption);
+        command.Add(chatHistoryOption);
+        command.Add(modelOption);
 
-        var modelOption = new Option<string>(
-            aliases: ["--model"],
-            description: "The OpenAI model to use",
-            getDefaultValue: () => "gpt-5-nano")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(messageOption);
-        command.AddOption(chatHistoryOption);
-        command.AddOption(modelOption);
-
-        command.SetHandler(async (string message, string? chatHistory, string model) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var message = parseResult.GetValue(messageOption)!;
+                var chatHistory = parseResult.GetValue(chatHistoryOption);
+                var model = parseResult.GetValue(modelOption)!;
+
                 var openAiClientService = new OpenAiClientService(model);
                 var chatComponent = new ChatComponent(openAiClientService);
                 var response = await chatComponent.ChatAsync(message, chatHistory);
@@ -63,7 +49,7 @@ public static class OpenAiCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, messageOption, chatHistoryOption, modelOption);
+        });
 
         return command;
     }
@@ -72,36 +58,22 @@ public static class OpenAiCommand
     {
         var command = new Command("translate", "Translate text to a target language using OpenAI");
 
-        var textOption = new Option<string>(
-            aliases: ["--text"],
-            description: "The text to translate")
-        {
-            IsRequired = true
-        };
+        var textOption = new Option<string>("--text") { Description = "The text to translate", Required = true };
+        var targetLanguageOption = new Option<string>("--target-language") { Description = "The target language to translate to", Required = true };
+        var modelOption = new Option<string>("--model") { Description = "The OpenAI model to use", DefaultValueFactory = _ => "gpt-5-nano" };
 
-        var targetLanguageOption = new Option<string>(
-            aliases: ["--target-language"],
-            description: "The target language to translate to")
-        {
-            IsRequired = true
-        };
+        command.Add(textOption);
+        command.Add(targetLanguageOption);
+        command.Add(modelOption);
 
-        var modelOption = new Option<string>(
-            aliases: ["--model"],
-            description: "The OpenAI model to use",
-            getDefaultValue: () => "gpt-5-nano")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(textOption);
-        command.AddOption(targetLanguageOption);
-        command.AddOption(modelOption);
-
-        command.SetHandler(async (string text, string targetLanguage, string model) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var text = parseResult.GetValue(textOption)!;
+                var targetLanguage = parseResult.GetValue(targetLanguageOption)!;
+                var model = parseResult.GetValue(modelOption)!;
+
                 var openAiClientService = new OpenAiClientService(model);
                 var translateComponent = new TranslateComponent(openAiClientService);
                 var translation = await translateComponent.TranslateAsync(text, targetLanguage);
@@ -113,7 +85,7 @@ public static class OpenAiCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, textOption, targetLanguageOption, modelOption);
+        });
 
         return command;
     }
@@ -122,28 +94,19 @@ public static class OpenAiCommand
     {
         var command = new Command("ocaaar", "Extract text from an image and translate it to pirate speak");
 
-        var imagePathOption = new Option<string>(
-            aliases: ["--image-path"],
-            description: "Path to the image file to process")
-        {
-            IsRequired = true
-        };
+        var imagePathOption = new Option<string>("--image-path") { Description = "Path to the image file to process", Required = true };
+        var modelOption = new Option<string>("--model") { Description = "The OpenAI model to use", DefaultValueFactory = _ => "gpt-5-nano" };
 
-        var modelOption = new Option<string>(
-            aliases: ["--model"],
-            description: "The OpenAI model to use",
-            getDefaultValue: () => "gpt-5-nano")
-        {
-            IsRequired = false
-        };
+        command.Add(imagePathOption);
+        command.Add(modelOption);
 
-        command.AddOption(imagePathOption);
-        command.AddOption(modelOption);
-
-        command.SetHandler(async (string imagePath, string model) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var imagePath = parseResult.GetValue(imagePathOption)!;
+                var model = parseResult.GetValue(modelOption)!;
+
                 var openAiClientService = new OpenAiClientService(model);
                 var ocaaarComponent = new OcaaarComponent(openAiClientService);
                 var response = await ocaaarComponent.OcaaarAsync(imagePath);
@@ -155,7 +118,7 @@ public static class OpenAiCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, imagePathOption, modelOption);
+        });
 
         return command;
     }
@@ -164,48 +127,28 @@ public static class OpenAiCommand
     {
         var command = new Command("corpospeak", "Rewrite text for enterprise audiences with optional idiolect adaptation");
 
-        var sourceOption = new Option<string>(
-            aliases: ["--source"],
-            description: "The source text to rewrite (or path to file containing the text)")
-        {
-            IsRequired = true
-        };
+        var sourceOption = new Option<string>("--source") { Description = "The source text to rewrite (or path to file containing the text)", Required = true };
+        var audienceOption = new Option<string>("--audience") { Description = "Target audience (csuite, engineering, product, sales, marketing, operations, finance, legal, hr, customer-success)", Required = true };
+        var userMessagesOption = new Option<string[]>("--user-messages") { Description = "Optional user messages to learn idiolect from (text or file paths, multiple values allowed)", AllowMultipleArgumentsPerToken = true };
+        var modelOption = new Option<string>("--model") { Description = "The OpenAI model to use", DefaultValueFactory = _ => "gpt-5-nano" };
 
-        var audienceOption = new Option<string>(
-            aliases: ["--audience"],
-            description: "Target audience (csuite, engineering, product, sales, marketing, operations, finance, legal, hr, customer-success)")
-        {
-            IsRequired = true
-        };
+        command.Add(sourceOption);
+        command.Add(audienceOption);
+        command.Add(userMessagesOption);
+        command.Add(modelOption);
 
-        var userMessagesOption = new Option<string[]>(
-            aliases: ["--user-messages"],
-            description: "Optional user messages to learn idiolect from (text or file paths, multiple values allowed)")
-        {
-            IsRequired = false,
-            AllowMultipleArgumentsPerToken = true
-        };
-
-        var modelOption = new Option<string>(
-            aliases: ["--model"],
-            description: "The OpenAI model to use",
-            getDefaultValue: () => "gpt-5-nano")
-        {
-            IsRequired = false
-        };
-
-        command.AddOption(sourceOption);
-        command.AddOption(audienceOption);
-        command.AddOption(userMessagesOption);
-        command.AddOption(modelOption);
-
-        command.SetHandler(async (string source, string audience, string[] userMessages, string model) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var source = parseResult.GetValue(sourceOption)!;
+                var audience = parseResult.GetValue(audienceOption)!;
+                var userMessages = parseResult.GetValue(userMessagesOption) ?? [];
+                var model = parseResult.GetValue(modelOption)!;
+
                 var openAiClientService = new OpenAiClientService(model);
                 var corpospeakComponent = new CorpospeakComponent(openAiClientService);
-                var result = await corpospeakComponent.CorpospeakAsync(source, audience, userMessages ?? []);
+                var result = await corpospeakComponent.CorpospeakAsync(source, audience, userMessages);
 
                 Console.WriteLine(result);
             }
@@ -214,7 +157,7 @@ public static class OpenAiCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, sourceOption, audienceOption, userMessagesOption, modelOption);
+        });
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Commands/StringsCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/StringsCommand.cs
@@ -9,10 +9,10 @@ public static class StringsCommand
     {
         var command = new Command("strings", "String manipulation utilities");
 
-        command.AddCommand(CreateReverseCommand());
-        command.AddCommand(CreateLevenshteinDistanceCommand());
-        command.AddCommand(CreateAbjadifyCommand());
-        command.AddCommand(CreateFleschReadingEaseCommand());
+        command.Add(CreateReverseCommand());
+        command.Add(CreateLevenshteinDistanceCommand());
+        command.Add(CreateAbjadifyCommand());
+        command.Add(CreateFleschReadingEaseCommand());
 
         return command;
     }
@@ -21,30 +21,21 @@ public static class StringsCommand
     {
         var command = new Command("reverse", "Reverses the content of a file");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Input file path")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Input file path", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Output file path", Required = true };
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Output file path")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(outFileOption);
 
-        command.AddOption(inFileOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
                 var stringReverser = new StringReverser();
                 await stringReverser.ReverseFileAsync(inFile, outFile);
-                
+
                 Console.WriteLine($"Successfully reversed content from '{inFile}' to '{outFile}'");
             }
             catch (Exception ex)
@@ -52,7 +43,7 @@ public static class StringsCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, outFileOption);
+        });
 
         return command;
     }
@@ -61,30 +52,21 @@ public static class StringsCommand
     {
         var command = new Command("levenshtein-distance", "Calculates the Levenshtein distance between two strings or files");
 
-        var string1Option = new Option<string>(
-            aliases: ["--string1"],
-            description: "First string or file path")
-        {
-            IsRequired = true
-        };
+        var string1Option = new Option<string>("--string1") { Description = "First string or file path", Required = true };
+        var string2Option = new Option<string>("--string2") { Description = "Second string or file path", Required = true };
 
-        var string2Option = new Option<string>(
-            aliases: ["--string2"],
-            description: "Second string or file path")
-        {
-            IsRequired = true
-        };
+        command.Add(string1Option);
+        command.Add(string2Option);
 
-        command.AddOption(string1Option);
-        command.AddOption(string2Option);
-
-        command.SetHandler(async (string string1, string string2) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var string1 = parseResult.GetValue(string1Option)!;
+                var string2 = parseResult.GetValue(string2Option)!;
                 var calculator = new LevenshteinCalculator();
                 var distance = await calculator.CalculateDistanceAsync(string1, string2);
-                
+
                 Console.WriteLine($"Levenshtein distance: {distance}");
             }
             catch (Exception ex)
@@ -92,7 +74,7 @@ public static class StringsCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, string1Option, string2Option);
+        });
 
         return command;
     }
@@ -101,27 +83,18 @@ public static class StringsCommand
     {
         var command = new Command("abjadify", "Strips English vowels from text while preserving single vowel words");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Input file path")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Input file path", Required = true };
+        var outFileOption = new Option<string>("--out-file") { Description = "Output file path", Required = true };
 
-        var outFileOption = new Option<string>(
-            aliases: ["--out-file"],
-            description: "Output file path")
-        {
-            IsRequired = true
-        };
+        command.Add(inFileOption);
+        command.Add(outFileOption);
 
-        command.AddOption(inFileOption);
-        command.AddOption(outFileOption);
-
-        command.SetHandler(async (string inFile, string outFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
+                var outFile = parseResult.GetValue(outFileOption)!;
                 var abjadifyComponent = new AbjadifyComponent();
                 await abjadifyComponent.AbjadifyFileAsync(inFile, outFile);
 
@@ -132,7 +105,7 @@ public static class StringsCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption, outFileOption);
+        });
 
         return command;
     }
@@ -141,19 +114,15 @@ public static class StringsCommand
     {
         var command = new Command("flesch-reading-ease", "Analyzes plain text readability using the Flesch Reading Ease score");
 
-        var inFileOption = new Option<string>(
-            aliases: ["--in-file"],
-            description: "Input plain-text file path")
-        {
-            IsRequired = true
-        };
+        var inFileOption = new Option<string>("--in-file") { Description = "Input plain-text file path", Required = true };
 
-        command.AddOption(inFileOption);
+        command.Add(inFileOption);
 
-        command.SetHandler(async (string inFile) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var inFile = parseResult.GetValue(inFileOption)!;
                 var component = new FleschReadingEaseComponent();
                 var result = await component.AnalyzeFileAsync(inFile);
 
@@ -168,7 +137,7 @@ public static class StringsCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, inFileOption);
+        });
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Commands/WebCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/WebCommand.cs
@@ -12,7 +12,7 @@ public static class WebCommand
     {
         var command = new Command("web", "Web server utilities");
 
-        command.AddCommand(CreateServeHtmlCommand());
+        command.Add(CreateServeHtmlCommand());
 
         return command;
     }
@@ -21,28 +21,19 @@ public static class WebCommand
     {
         var command = new Command("serve-html", "Serves a static HTML file via HTTP server");
 
-        var fileOption = new Option<string>(
-            aliases: ["--file"],
-            description: "Path to the HTML file to serve")
-        {
-            IsRequired = true
-        };
+        var fileOption = new Option<string>("--file") { Description = "Path to the HTML file to serve", Required = true };
+        var portOption = new Option<int>("--port") { Description = "Port to bind the server to", DefaultValueFactory = _ => 8080 };
 
-        var portOption = new Option<int>(
-            aliases: ["--port"],
-            description: "Port to bind the server to")
-        {
-            IsRequired = false
-        };
-        portOption.SetDefaultValue(8080);
+        command.Add(fileOption);
+        command.Add(portOption);
 
-        command.AddOption(fileOption);
-        command.AddOption(portOption);
-
-        command.SetHandler(async (string file, int port) =>
+        command.SetAction(async (parseResult, cancellationToken) =>
         {
             try
             {
+                var file = parseResult.GetValue(fileOption)!;
+                var port = parseResult.GetValue(portOption);
+
                 if (!File.Exists(file))
                 {
                     Console.WriteLine($"Error: File '{file}' not found");
@@ -86,7 +77,7 @@ public static class WebCommand
                 Console.WriteLine($"Error: {ex.Message}");
                 Environment.Exit(1);
             }
-        }, fileOption, portOption);
+        });
 
         return command;
     }

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, OpenAI integration, and homomorphic encryption.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;openai;crypto;homomorphic-encryption</PackageTags>
@@ -28,12 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.5.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.0.1-preview.1.24570.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
 
 </Project>

--- a/Pixelbadger.Toolkit/Program.cs
+++ b/Pixelbadger.Toolkit/Program.cs
@@ -1,14 +1,14 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using Pixelbadger.Toolkit.Commands;
 
 var rootCommand = new RootCommand("CLI toolkit exposing varied functionality organized by topic");
 
-rootCommand.AddCommand(StringsCommand.Create());
-rootCommand.AddCommand(InterpretersCommand.Create());
-rootCommand.AddCommand(ImagesCommand.Create());
-rootCommand.AddCommand(WebCommand.Create());
-rootCommand.AddCommand(OpenAiCommand.Create());
-rootCommand.AddCommand(OAuthCommand.Create());
-rootCommand.AddCommand(CryptoCommand.Create());
+rootCommand.Add(StringsCommand.Create());
+rootCommand.Add(InterpretersCommand.Create());
+rootCommand.Add(ImagesCommand.Create());
+rootCommand.Add(WebCommand.Create());
+rootCommand.Add(OpenAiCommand.Create());
+rootCommand.Add(OAuthCommand.Create());
+rootCommand.Add(CryptoCommand.Create());
 
-return await rootCommand.InvokeAsync(args);
+return await rootCommand.Parse(args).InvokeAsync();


### PR DESCRIPTION
Closes #27

## Summary
- Updates all NuGet packages to their latest compatible versions
- Migrates System.CommandLine from `2.0.0-beta4.22272.1` to `2.0.8` (stable), which required updating all command files to use the new API (`Add` instead of `AddCommand`/`AddOption`, `SetAction` instead of `SetHandler`, `ParseResult.GetValue` to extract values in handlers)
- Bumps version to 4.1.2 (PATCH)
- SixLabors.ImageSharp is **not** updated: v4.0.0 requires a paid commercial licence, so it is held at 3.1.11

**Packages updated:**
| Package | Old | New |
|---|---|---|
| Microsoft.Extensions.AI | 9.5.0 | 10.6.0 |
| Microsoft.Extensions.AI.OpenAI | 9.0.1-preview | 10.6.0 |
| Microsoft.Extensions.Hosting | 8.0.0 | 10.0.8 |
| OpenAI | 2.1.0 / 2.4.0 | 2.10.0 |
| System.CommandLine | 2.0.0-beta4 | 2.0.8 |
| coverlet.collector | 6.0.2 | 10.0.1 |
| FluentAssertions | 8.6.0 | 8.10.0 |
| Microsoft.NET.Test.Sdk | 17.12.0 | 18.6.0 |
| xunit | 2.9.2 | 2.9.3 |
| xunit.runner.visualstudio | 2.8.2 | 3.1.5 |

## Test plan
- [x] Tests pass: `dotnet test` (329/329)
- [x] Version bumped in csproj (4.1.1 → 4.1.2)