### PR TITLE
Add HTML documentation for all topics with index

### DIFF
--- a/docs/images.html
+++ b/docs/images.html
@@ -1,0 +1,454 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — Images</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    .math-block {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 1rem 1.25rem;
+      margin: 0.75rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.9rem;
+      color: #93c5fd;
+      overflow-x: auto;
+    }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .key-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin: 1rem 0;
+    }
+
+    .key-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+
+    .key-card .label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #64748b;
+      margin-bottom: 0.25rem;
+    }
+
+    .key-card .name {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #60a5fa;
+      margin-bottom: 0.35rem;
+    }
+
+    .key-card p {
+      font-size: 0.82rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    .warning-box {
+      background: #1c1008;
+      border: 1px solid #92400e;
+      border-left: 3px solid #f59e0b;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #fcd34d;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Images <span class="badge">images</span></h1>
+  <div class="subtitle">Image steganography — hide and recover secret messages in the least-significant bits of image pixels</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk images</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#overview">Overview</a>
+  <a href="#how-it-works">How It Works</a>
+  <a href="#encode">Encode</a>
+  <a href="#decode">Decode</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- OVERVIEW -->
+  <section id="overview">
+    <h2>Overview</h2>
+    <p>
+      The <code>steganography</code> command lets you hide a text message inside an image file and later
+      recover it. The message is stored in the least-significant bits of the R, G, and B channels of
+      each pixel in scan order, so the visual change to the image is imperceptible to the human eye.
+    </p>
+
+    <div class="key-grid">
+      <div class="key-card">
+        <div class="label">Method</div>
+        <div class="name">LSB Steganography</div>
+        <p>One bit stored per colour channel. Three bits per pixel.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Encoding</div>
+        <div class="name">UTF-8</div>
+        <p>Message is converted to UTF-8 bytes before bit-packing.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Terminator</div>
+        <div class="name">&lt;&lt;END&gt;&gt;</div>
+        <p>Appended to the message so decoding knows where to stop.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Library</div>
+        <div class="name">ImageSharp</div>
+        <p>SixLabors.ImageSharp handles pixel-level access for all supported formats.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <section id="how-it-works">
+    <h2>How It Works</h2>
+
+    <h3>Encoding</h3>
+    <p>
+      The message is appended with the sentinel string <code>&lt;&lt;END&gt;&gt;</code>, converted to UTF-8 bytes,
+      then expanded to a bit array. The bits are written into the least-significant bit of each colour
+      channel (R, G, B) in left-to-right, top-to-bottom pixel order.
+    </p>
+    <div class="math-block">pixel.R = (pixel.R &amp; 0xFE) | messageBits[i]
+pixel.G = (pixel.G &amp; 0xFE) | messageBits[i+1]
+pixel.B = (pixel.B &amp; 0xFE) | messageBits[i+2]</div>
+
+    <h3>Decoding</h3>
+    <p>
+      The LSBs of R, G, and B are read from each pixel in the same scan order, accumulated into bytes,
+      and converted back to a UTF-8 string until the <code>&lt;&lt;END&gt;&gt;</code> sentinel is found.
+      Everything before the sentinel is the recovered message.
+    </p>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart TD
+    MSG["Plaintext message"] --> UTF8["UTF-8 encode + append &lt;&lt;END&gt;&gt;"]
+    UTF8 --> BITS["Expand to bit array\n8 bits per byte"]
+    BITS --> PACK["Write one bit into LSB\nof each R, G, B channel\nper pixel (scan order)"]
+    IMG["Input image"] --> PACK
+    PACK --> OUT["Output image\n(visually identical)"]
+      </div>
+    </div>
+
+    <div class="info-box">
+      The message capacity of an image is <strong>floor(width × height × 3 / 8)</strong> bytes
+      (minus the 7-byte terminator). A 100 × 100 image holds roughly 3,750 bytes of message text.
+    </div>
+
+    <div class="warning-box">
+      <strong>Output format matters:</strong> save the encoded image as a lossless format (PNG, BMP).
+      Saving as JPEG re-compresses the pixel data and will corrupt the hidden bits, making the message
+      unrecoverable.
+    </div>
+  </section>
+
+  <!-- ENCODE -->
+  <section id="encode">
+    <h2>Encode</h2>
+    <p>Hide a message inside an image. The output file is a new image with the message bits written
+    into the least-significant channel bits.</p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk images steganography</span>
+      <span class="opt"> --mode</span> <span class="val">encode</span>
+      <span class="opt"> --image</span> <span class="val">cover.png</span>
+      <span class="opt"> --message</span> <span class="val">"Secret payload"</span>
+      <span class="opt"> --output</span> <span class="val">stego.png</span>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--mode</code></td><td>Yes</td><td>Must be <code>encode</code></td></tr>
+        <tr><td><code>--image</code></td><td>Yes</td><td>Path to the input cover image</td></tr>
+        <tr><td><code>--message</code></td><td>Yes (encode)</td><td>The plaintext message to hide</td></tr>
+        <tr><td><code>--output</code></td><td>Yes (encode)</td><td>Path to write the output stego image</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- DECODE -->
+  <section id="decode">
+    <h2>Decode</h2>
+    <p>Recover a previously hidden message from a stego image. The image must have been produced
+    by the encode mode of this same command.</p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk images steganography</span>
+      <span class="opt"> --mode</span> <span class="val">decode</span>
+      <span class="opt"> --image</span> <span class="val">stego.png</span>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--mode</code></td><td>Yes</td><td>Must be <code>decode</code></td></tr>
+        <tr><td><code>--image</code></td><td>Yes</td><td>Path to the stego image containing a hidden message</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>images steganography --mode encode</code></td>
+          <td><code>--image</code> <code>--message</code> <code>--output</code></td>
+          <td>&mdash;</td>
+          <td>Stego image written to <code>--output</code></td>
+        </tr>
+        <tr>
+          <td><code>images steganography --mode decode</code></td>
+          <td><code>--image</code></td>
+          <td>&mdash;</td>
+          <td>Recovered message printed to stdout</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Constraints and Limits</h3>
+    <table>
+      <thead><tr><th>Constraint</th><th>Value</th><th>Reason</th></tr></thead>
+      <tbody>
+        <tr>
+          <td>Bits per pixel</td>
+          <td>3 (one per R/G/B channel)</td>
+          <td>LSB of alpha channel is left untouched to avoid transparency artefacts</td>
+        </tr>
+        <tr>
+          <td>Message terminator</td>
+          <td><code>&lt;&lt;END&gt;&gt;</code> (7 bytes)</td>
+          <td>Required for the decoder to know when the message ends</td>
+        </tr>
+        <tr>
+          <td>Output format</td>
+          <td>Lossless (PNG, BMP recommended)</td>
+          <td>Lossy compression (JPEG) destroys the hidden bits</td>
+        </tr>
+        <tr>
+          <td>Message encoding</td>
+          <td>UTF-8</td>
+          <td>Full Unicode supported; multi-byte characters consume more capacity</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; Images Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — Documentation</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    .topic-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 1.25rem;
+      margin-top: 1.5rem;
+    }
+
+    .topic-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 1.5rem;
+      text-decoration: none;
+      display: block;
+      transition: border-color 0.15s, background 0.15s;
+    }
+
+    .topic-card:hover {
+      border-color: #60a5fa;
+      background: #1e3a5f;
+    }
+
+    .topic-card .topic-name {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #60a5fa;
+      font-family: 'Courier New', monospace;
+      margin-bottom: 0.4rem;
+    }
+
+    .topic-card .topic-desc {
+      font-size: 0.88rem;
+      color: #94a3b8;
+      margin-bottom: 0.75rem;
+    }
+
+    .topic-card .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
+
+    .action-tag {
+      background: #0f172a;
+      border: 1px solid #334155;
+      color: #7dd3fc;
+      font-size: 0.75rem;
+      font-family: 'Courier New', monospace;
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Pixelbadger Toolkit</h1>
+  <div class="subtitle">Documentation index — all topics and commands</div>
+  <div class="meta">CLI tool &mdash; <code>pbtk [topic] [action] [options]</code></div>
+</header>
+
+<div class="content">
+
+  <section>
+    <h2>Overview</h2>
+    <p>
+      Pixelbadger Toolkit (<code>pbtk</code>) is a CLI tool that organises varied utilities under topic-based
+      commands. Each topic groups related actions behind a consistent argument pattern:
+    </p>
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk</span>
+      <span class="val"> &lt;topic&gt;</span>
+      <span class="val"> &lt;action&gt;</span>
+      <span class="opt"> [options]</span>
+    </div>
+    <p>
+      Select a topic below to read detailed documentation for every command it exposes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Topics</h2>
+    <div class="topic-grid">
+
+      <a class="topic-card" href="strings.html">
+        <div class="topic-name">pbtk strings</div>
+        <div class="topic-desc">String manipulation utilities — reversals, edit distance, vowel stripping, and readability analysis.</div>
+        <div class="actions">
+          <span class="action-tag">reverse</span>
+          <span class="action-tag">levenshtein-distance</span>
+          <span class="action-tag">abjadify</span>
+          <span class="action-tag">flesch-reading-ease</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="interpreters.html">
+        <div class="topic-name">pbtk interpreters</div>
+        <div class="topic-desc">Esoteric language interpreters — execute Brainfuck and Ook programs, or translate between them.</div>
+        <div class="actions">
+          <span class="action-tag">brainfuck</span>
+          <span class="action-tag">ook</span>
+          <span class="action-tag">bf-to-ook</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="images.html">
+        <div class="topic-name">pbtk images</div>
+        <div class="topic-desc">Image processing utilities — hide and recover secret messages using LSB steganography.</div>
+        <div class="actions">
+          <span class="action-tag">steganography</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="web.html">
+        <div class="topic-name">pbtk web</div>
+        <div class="topic-desc">Local web utilities — serve a single HTML file over HTTP for quick previewing.</div>
+        <div class="actions">
+          <span class="action-tag">serve-html</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="openai.html">
+        <div class="topic-name">pbtk openai</div>
+        <div class="topic-desc">OpenAI-powered utilities — conversational chat, translation, OCR with pirate speak, and corpospeak rewriting.</div>
+        <div class="actions">
+          <span class="action-tag">chat</span>
+          <span class="action-tag">translate</span>
+          <span class="action-tag">ocaaar</span>
+          <span class="action-tag">corpospeak</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="oauth.html">
+        <div class="topic-name">pbtk oauth</div>
+        <div class="topic-desc">OAuth utilities — acquire access tokens and manage named connection profiles.</div>
+        <div class="actions">
+          <span class="action-tag">token</span>
+          <span class="action-tag">profile add</span>
+          <span class="action-tag">profile update</span>
+          <span class="action-tag">profile delete</span>
+        </div>
+      </a>
+
+      <a class="topic-card" href="paillier-encryption.html">
+        <div class="topic-name">pbtk crypto</div>
+        <div class="topic-desc">Paillier homomorphic encryption — generate keys, encrypt integers and strings, and perform arithmetic on ciphertext without decrypting.</div>
+        <div class="actions">
+          <span class="action-tag">generate-key</span>
+          <span class="action-tag">encrypt</span>
+          <span class="action-tag">decrypt</span>
+          <span class="action-tag">add</span>
+          <span class="action-tag">subtract</span>
+          <span class="action-tag">multiply</span>
+          <span class="action-tag">encrypt-string</span>
+          <span class="action-tag">decrypt-string</span>
+          <span class="action-tag">replace</span>
+          <span class="action-tag">substring</span>
+        </div>
+      </a>
+
+    </div>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; Documentation
+</footer>
+
+</body>
+</html>

--- a/docs/interpreters.html
+++ b/docs/interpreters.html
@@ -1,0 +1,496 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — Interpreters</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .card h3 { margin-top: 0; color: #e2e8f0; }
+    .card p { margin-bottom: 0.5rem; }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .op-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+
+    .op-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.9rem;
+    }
+
+    .op-card .symbol {
+      font-size: 1.3rem;
+      font-weight: 700;
+      font-family: 'Courier New', monospace;
+      color: #22d3ee;
+      margin-bottom: 0.2rem;
+    }
+
+    .op-card p {
+      font-size: 0.8rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .ook-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+
+    .ook-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.9rem 1rem;
+    }
+
+    .ook-card .ook-token {
+      font-family: 'Courier New', monospace;
+      font-size: 0.78rem;
+      color: #a78bfa;
+      margin-bottom: 0.25rem;
+    }
+
+    .ook-card .bf-equiv {
+      font-family: 'Courier New', monospace;
+      font-size: 0.8rem;
+      color: #22d3ee;
+      margin-bottom: 0.2rem;
+    }
+
+    .ook-card p {
+      font-size: 0.8rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Interpreters <span class="badge">interpreters</span></h1>
+  <div class="subtitle">Esoteric language interpreters — execute Brainfuck and Ook programs, or translate between them</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk interpreters</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#brainfuck">brainfuck</a>
+  <a href="#ook">ook</a>
+  <a href="#bf-to-ook">bf-to-ook</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- BRAINFUCK -->
+  <section id="brainfuck">
+    <h2>brainfuck</h2>
+    <p>
+      Executes a Brainfuck program read from a file. Brainfuck is a Turing-complete esoteric language
+      with only eight instructions that operate on a tape of 30,000 byte cells.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk interpreters brainfuck</span>
+      <span class="opt"> --file</span> <span class="val">hello.bf</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    F["hello.bf\nBrainfuck source"] --> PARSE["Read program text"]
+    PARSE --> EXEC["Execute on\n30,000-byte tape"]
+    EXEC --> OUT(["stdout: program output"])
+      </div>
+    </div>
+
+    <h3>Instruction Set</h3>
+    <div class="op-grid">
+      <div class="op-card">
+        <div class="symbol">&gt;</div>
+        <p>Move data pointer right one cell.</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">&lt;</div>
+        <p>Move data pointer left one cell.</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">+</div>
+        <p>Increment the current cell by 1 (wraps at 255).</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">-</div>
+        <p>Decrement the current cell by 1 (wraps at 0).</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">.</div>
+        <p>Output the current cell as an ASCII character.</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">,</div>
+        <p>Read one character from stdin into the current cell.</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">[</div>
+        <p>If the current cell is 0, jump forward to the matching <code>]</code>.</p>
+      </div>
+      <div class="op-card">
+        <div class="symbol">]</div>
+        <p>If the current cell is non-zero, jump back to the matching <code>[</code>.</p>
+      </div>
+    </div>
+
+    <div class="info-box">
+      All characters other than <code>&gt; &lt; + - . , [ ]</code> are treated as comments and ignored.
+      The tape is 30,000 bytes, all initialised to zero.
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--file</code></td><td>Yes</td><td>Path to the Brainfuck program file (<code>.bf</code>)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- OOK -->
+  <section id="ook">
+    <h2>ook</h2>
+    <p>
+      Executes an Ook! program read from a file. Ook! is a joke language invented by David Morgan-Mar
+      that is semantically identical to Brainfuck but uses only the word "Ook" combined with punctuation.
+      Each instruction is a two-token pair.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk interpreters ook</span>
+      <span class="opt"> --file</span> <span class="val">hello.ook</span>
+    </div>
+
+    <h3>Instruction Mapping</h3>
+    <div class="ook-grid">
+      <div class="ook-card">
+        <div class="ook-token">Ook. Ook?</div>
+        <div class="bf-equiv">→ &gt;</div>
+        <p>Move pointer right.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook? Ook.</div>
+        <div class="bf-equiv">→ &lt;</div>
+        <p>Move pointer left.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook. Ook.</div>
+        <div class="bf-equiv">→ +</div>
+        <p>Increment current cell.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook! Ook!</div>
+        <div class="bf-equiv">→ -</div>
+        <p>Decrement current cell.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook! Ook.</div>
+        <div class="bf-equiv">→ .</div>
+        <p>Output current cell as ASCII.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook. Ook!</div>
+        <div class="bf-equiv">→ ,</div>
+        <p>Read character into current cell.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook! Ook?</div>
+        <div class="bf-equiv">→ [</div>
+        <p>Jump forward if cell is zero.</p>
+      </div>
+      <div class="ook-card">
+        <div class="ook-token">Ook? Ook!</div>
+        <div class="bf-equiv">→ ]</div>
+        <p>Jump back if cell is non-zero.</p>
+      </div>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--file</code></td><td>Yes</td><td>Path to the Ook program file (<code>.ook</code>)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- BF-TO-OOK -->
+  <section id="bf-to-ook">
+    <h2>bf-to-ook</h2>
+    <p>
+      Translates a Brainfuck source file into equivalent Ook! source and writes the output to a file.
+      The conversion is a straightforward one-to-one token substitution — every Brainfuck instruction
+      becomes its two-token Ook! equivalent separated by a space.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk interpreters bf-to-ook</span>
+      <span class="opt"> --source</span> <span class="val">hello.bf</span>
+      <span class="opt"> --output</span> <span class="val">hello.ook</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    BF["hello.bf\n&gt;&lt;+-.,[]"] --> MAP["One-to-one\ninstruction substitution"]
+    MAP --> OOK["hello.ook\nOok. Ook? Ook? Ook. ..."]
+      </div>
+    </div>
+
+    <div class="info-box">
+      Non-instruction characters (comments) in the Brainfuck source are silently dropped — the output
+      Ook file contains only valid Ook tokens.
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--source</code></td><td>Yes</td><td>Path to the source Brainfuck file to translate</td></tr>
+        <tr><td><code>--output</code></td><td>Yes</td><td>Path to write the generated Ook file</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>interpreters brainfuck</code></td>
+          <td><code>--file</code></td>
+          <td>&mdash;</td>
+          <td>Program output to stdout</td>
+        </tr>
+        <tr>
+          <td><code>interpreters ook</code></td>
+          <td><code>--file</code></td>
+          <td>&mdash;</td>
+          <td>Program output to stdout</td>
+        </tr>
+        <tr>
+          <td><code>interpreters bf-to-ook</code></td>
+          <td><code>--source</code> <code>--output</code></td>
+          <td>&mdash;</td>
+          <td>Ook source written to <code>--output</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; Interpreters Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/oauth.html
+++ b/docs/oauth.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — OAuth</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .key-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin: 1rem 0;
+    }
+
+    .key-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+
+    .key-card .label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #64748b;
+      margin-bottom: 0.25rem;
+    }
+
+    .key-card .name {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #60a5fa;
+      margin-bottom: 0.35rem;
+    }
+
+    .key-card p {
+      font-size: 0.82rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    .warning-box {
+      background: #1c1008;
+      border: 1px solid #92400e;
+      border-left: 3px solid #f59e0b;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #fcd34d;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>OAuth <span class="badge">oauth</span></h1>
+  <div class="subtitle">OAuth utilities — acquire access tokens and manage named connection profiles</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk oauth</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#overview">Overview</a>
+  <a href="#token">token</a>
+  <a href="#profile">profile</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- OVERVIEW -->
+  <section id="overview">
+    <h2>Overview</h2>
+    <p>
+      The <code>oauth</code> topic provides two capabilities: acquiring an OAuth 2.0 access token using
+      the Resource Owner Password Credentials (ROPC) grant, and managing the named profiles that store
+      the connection settings for each OAuth endpoint.
+    </p>
+    <p>
+      Profiles are stored locally and referenced by name when acquiring tokens. This avoids repeating
+      authority URLs and client credentials on every invocation.
+    </p>
+
+    <div class="key-grid">
+      <div class="key-card">
+        <div class="label">Grant type</div>
+        <div class="name">ROPC</div>
+        <p>Resource Owner Password Credentials. Username and password are supplied interactively at runtime.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Profile storage</div>
+        <div class="name">Local file</div>
+        <p>Profiles are persisted in a local configuration file managed by the toolkit.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Secrets</div>
+        <div class="name">Secure input</div>
+        <p>Passwords and client secrets are read with echo suppressed so they do not appear in the terminal.</p>
+      </div>
+      <div class="key-card">
+        <div class="label">Output</div>
+        <div class="name">stdout token</div>
+        <p>The raw access token is printed to stdout, suitable for scripting with <code>$()</code> substitution.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- TOKEN -->
+  <section id="token">
+    <h2>token</h2>
+    <p>
+      Acquires an OAuth access token for the specified profile using the Resource Owner Password Credentials
+      grant. Username is prompted on stdout; password is read silently (no echo). The access token is
+      printed to stdout on success.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk oauth token</span>
+      <span class="opt"> --profile</span> <span class="val">my-api</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart TD
+    CLI["pbtk oauth token\n--profile my-api"] --> LOAD["Load profile\n(authority, client-id, scope)"]
+    LOAD --> UNAME["Prompt: Username"]
+    UNAME --> PASS["Prompt: Password\n(silent input)"]
+    PASS --> HTTP["POST /token\ngrant_type=password\nusername + password\nclient credentials"]
+    HTTP --> OUT(["stdout: access_token"])
+      </div>
+    </div>
+
+    <div class="warning-box">
+      <strong>ROPC is a legacy grant.</strong> Many modern identity providers disable it by default.
+      It requires that the application handles user credentials directly — use it only with providers
+      and clients explicitly configured to allow it.
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--profile</code></td><td>Yes</td><td>Name of the saved OAuth profile to use for the token request</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- PROFILE -->
+  <section id="profile">
+    <h2>profile</h2>
+    <p>
+      Manages the named OAuth profiles used by the <code>token</code> command. Three sub-actions are
+      available: <code>add</code>, <code>update</code>, and <code>delete</code>.
+    </p>
+
+    <h3>profile add</h3>
+    <p>Creates a new named profile. The client secret is read silently if not supplied via the option.</p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk oauth profile add</span>
+      <span class="opt"> --name</span> <span class="val">my-api</span>
+      <span class="opt"> --authority</span> <span class="val">https://login.microsoftonline.com/tenant-id</span>
+      <span class="opt"> --client-id</span> <span class="val">xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</span>
+      <span class="opt"> --scope</span> <span class="val">api://my-api/.default</span>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--name</code></td><td>Yes</td><td>Unique profile name used when running <code>token</code></td></tr>
+        <tr><td><code>--authority</code></td><td>Yes</td><td>OAuth authority base URI (token endpoint is derived from this)</td></tr>
+        <tr><td><code>--client-id</code></td><td>Yes</td><td>OAuth application (client) ID</td></tr>
+        <tr><td><code>--client-secret</code></td><td>No</td><td>Client secret; prompted securely if omitted</td></tr>
+        <tr><td><code>--scope</code></td><td>No</td><td>OAuth scope(s) to request; omit for providers that use a fixed scope</td></tr>
+      </tbody>
+    </table>
+
+    <h3>profile update</h3>
+    <p>Updates one or more fields of an existing profile. Only the options supplied are changed; omitted options retain their current values.</p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk oauth profile update</span>
+      <span class="opt"> --name</span> <span class="val">my-api</span>
+      <span class="opt"> --scope</span> <span class="val">api://my-api/read</span>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--name</code></td><td>Yes</td><td>Name of the profile to update</td></tr>
+        <tr><td><code>--authority</code></td><td>No</td><td>New authority URI</td></tr>
+        <tr><td><code>--client-id</code></td><td>No</td><td>New client ID</td></tr>
+        <tr><td><code>--client-secret</code></td><td>No</td><td>New client secret; prompted securely if omitted and the flag is present</td></tr>
+        <tr><td><code>--scope</code></td><td>No</td><td>New scope</td></tr>
+      </tbody>
+    </table>
+
+    <h3>profile delete</h3>
+    <p>Removes a saved profile by name.</p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk oauth profile delete</span>
+      <span class="opt"> --name</span> <span class="val">my-api</span>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--name</code></td><td>Yes</td><td>Name of the profile to delete</td></tr>
+      </tbody>
+    </table>
+
+    <div class="info-box">
+      Profile names are case-sensitive. Deleting a profile that does not exist will return an error.
+    </div>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>oauth token</code></td>
+          <td><code>--profile</code></td>
+          <td>&mdash;</td>
+          <td>Access token printed to stdout</td>
+        </tr>
+        <tr>
+          <td><code>oauth profile add</code></td>
+          <td><code>--name</code> <code>--authority</code> <code>--client-id</code></td>
+          <td><code>--client-secret</code> <code>--scope</code></td>
+          <td>Confirmation message to stdout</td>
+        </tr>
+        <tr>
+          <td><code>oauth profile update</code></td>
+          <td><code>--name</code></td>
+          <td><code>--authority</code> <code>--client-id</code> <code>--client-secret</code> <code>--scope</code></td>
+          <td>Confirmation message to stdout</td>
+        </tr>
+        <tr>
+          <td><code>oauth profile delete</code></td>
+          <td><code>--name</code></td>
+          <td>&mdash;</td>
+          <td>Confirmation message to stdout</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; OAuth Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/openai.html
+++ b/docs/openai.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — OpenAI</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .audience-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.6rem;
+      margin: 1rem 0;
+    }
+
+    .audience-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.7rem 0.9rem;
+    }
+
+    .audience-card .aud-name {
+      font-family: 'Courier New', monospace;
+      font-size: 0.8rem;
+      color: #86efac;
+      font-weight: 600;
+      margin-bottom: 0.2rem;
+    }
+
+    .audience-card p {
+      font-size: 0.78rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>OpenAI <span class="badge">openai</span></h1>
+  <div class="subtitle">OpenAI-powered utilities — chat, translation, image OCR, and corpospeak rewriting</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk openai</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#prerequisites">Prerequisites</a>
+  <a href="#chat">chat</a>
+  <a href="#translate">translate</a>
+  <a href="#ocaaar">ocaaar</a>
+  <a href="#corpospeak">corpospeak</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- PREREQUISITES -->
+  <section id="prerequisites">
+    <h2>Prerequisites</h2>
+    <p>
+      All commands in this topic call the OpenAI API. The <code>OPENAI_API_KEY</code> environment variable
+      must be set before running any command.
+    </p>
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">export</span>
+      <span class="val"> OPENAI_API_KEY=sk-...</span>
+    </div>
+    <p>
+      By default all commands use the <code>gpt-5-nano</code> model. Pass <code>--model</code> to override.
+    </p>
+  </section>
+
+  <!-- CHAT -->
+  <section id="chat">
+    <h2>chat</h2>
+    <p>
+      Sends a message to the OpenAI chat completion API and prints the response. Conversation history
+      is persisted in a JSON file so that follow-up messages can reference earlier context.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai chat</span>
+      <span class="opt"> --message</span> <span class="val">"Hello, how are you?"</span>
+    </div>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai chat</span>
+      <span class="opt"> --message</span> <span class="val">"Continue our conversation"</span>
+      <span class="opt"> --chat-history</span> <span class="val">./chat.json</span>
+      <span class="opt"> --model</span> <span class="val">gpt-4o-mini</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    MSG["--message"] --> COMP["Append to history\nand send to\nOpenAI chat API"]
+    HIST["--chat-history\n(optional JSON file)"] --> COMP
+    COMP --> RESP(["stdout: assistant reply"])
+    COMP --> SAVE["Updated history\nwritten back to file"]
+      </div>
+    </div>
+
+    <p>
+      When <code>--chat-history</code> is provided, the file is read at startup to restore prior messages,
+      the new exchange is appended, and the file is rewritten. If the file does not exist it is created.
+      Omitting <code>--chat-history</code> starts a stateless single-turn conversation.
+    </p>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--message</code></td><td>Yes</td><td>&mdash;</td><td>The user message to send</td></tr>
+        <tr><td><code>--chat-history</code></td><td>No</td><td>&mdash;</td><td>JSON file to read/write conversation history</td></tr>
+        <tr><td><code>--model</code></td><td>No</td><td><code>gpt-5-nano</code></td><td>OpenAI model to use</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- TRANSLATE -->
+  <section id="translate">
+    <h2>translate</h2>
+    <p>
+      Translates a given text into a specified target language using the OpenAI API. The output is
+      the translated text printed to stdout. No conversation history is maintained.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai translate</span>
+      <span class="opt"> --text</span> <span class="val">"Hello, how are you?"</span>
+      <span class="opt"> --target-language</span> <span class="val">Spanish</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    T["--text"] --> CALL["OpenAI\nchat completion"]
+    LANG["--target-language"] --> CALL
+    CALL --> OUT(["stdout: translated text"])
+      </div>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--text</code></td><td>Yes</td><td>&mdash;</td><td>The text to translate</td></tr>
+        <tr><td><code>--target-language</code></td><td>Yes</td><td>&mdash;</td><td>Target language (e.g. <code>Spanish</code>, <code>French</code>, <code>Japanese</code>)</td></tr>
+        <tr><td><code>--model</code></td><td>No</td><td><code>gpt-5-nano</code></td><td>OpenAI model to use</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- OCAAAR -->
+  <section id="ocaaar">
+    <h2>ocaaar</h2>
+    <p>
+      <strong>OCR as a Pirate.</strong> Sends an image file to the OpenAI vision API, extracts any text
+      found in the image, and returns it rewritten in pirate speak. Useful for testing vision models
+      and for amusement.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai ocaaar</span>
+      <span class="opt"> --image-path</span> <span class="val">./sign.jpg</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    IMG["--image-path\n(local image file)"] --> ENC["Base64 encode\nimage"]
+    ENC --> CALL["OpenAI vision\nchat completion\n(extract text + pirate-speak prompt)"]
+    CALL --> OUT(["stdout: pirate-speak text"])
+      </div>
+    </div>
+
+    <div class="info-box">
+      The image is base64-encoded and sent inline with the API request. Supported formats are those
+      accepted by the OpenAI vision API: JPEG, PNG, GIF, and WebP.
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--image-path</code></td><td>Yes</td><td>&mdash;</td><td>Path to the image file to process</td></tr>
+        <tr><td><code>--model</code></td><td>No</td><td><code>gpt-5-nano</code></td><td>OpenAI model to use (must support vision)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- CORPOSPEAK -->
+  <section id="corpospeak">
+    <h2>corpospeak</h2>
+    <p>
+      Rewrites source text in the communication style appropriate for a chosen enterprise audience,
+      optionally learning from example messages to match an individual's idiolect. Input can be a
+      literal string or a file path.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai corpospeak</span>
+      <span class="opt"> --source</span> <span class="val">"API performance is great"</span>
+      <span class="opt"> --audience</span> <span class="val">csuite</span>
+    </div>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk openai corpospeak</span>
+      <span class="opt"> --source</span> <span class="val">"New feature deployed"</span>
+      <span class="opt"> --audience</span> <span class="val">engineering</span>
+      <span class="opt"> --user-messages</span> <span class="val">"Hey team"</span> <span class="val">"Let's ship this"</span>
+    </div>
+
+    <h3>Audiences</h3>
+    <div class="audience-grid">
+      <div class="audience-card"><div class="aud-name">csuite</div><p>Executive language, strategic framing.</p></div>
+      <div class="audience-card"><div class="aud-name">engineering</div><p>Technical, precise, low jargon.</p></div>
+      <div class="audience-card"><div class="aud-name">product</div><p>User-focused, outcome-driven.</p></div>
+      <div class="audience-card"><div class="aud-name">sales</div><p>Value propositions, persuasive tone.</p></div>
+      <div class="audience-card"><div class="aud-name">marketing</div><p>Brand voice, engaging copy.</p></div>
+      <div class="audience-card"><div class="aud-name">operations</div><p>Process-oriented, practical.</p></div>
+      <div class="audience-card"><div class="aud-name">finance</div><p>Metrics-focused, precise numbers.</p></div>
+      <div class="audience-card"><div class="aud-name">legal</div><p>Formal, risk-aware language.</p></div>
+      <div class="audience-card"><div class="aud-name">hr</div><p>People-centric, inclusive tone.</p></div>
+      <div class="audience-card"><div class="aud-name">customer-success</div><p>Empathetic, supportive language.</p></div>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    SRC["--source\n(text or file path)"] --> CALL["OpenAI\nchat completion\n(audience-tuned prompt)"]
+    AUD["--audience"] --> CALL
+    UM["--user-messages\n(optional idiolect examples)"] --> CALL
+    CALL --> OUT(["stdout: rewritten text"])
+      </div>
+    </div>
+
+    <p>
+      When <code>--user-messages</code> is provided, the examples are included in the prompt so the
+      model can infer and mimic the writer's personal style. Each value can be a literal string or
+      a path to a file containing example text. Multiple values are accepted.
+    </p>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--source</code></td><td>Yes</td><td>&mdash;</td><td>Source text to rewrite (or file path)</td></tr>
+        <tr><td><code>--audience</code></td><td>Yes</td><td>&mdash;</td><td>Target audience slug (see list above)</td></tr>
+        <tr><td><code>--user-messages</code></td><td>No</td><td>&mdash;</td><td>Example messages to learn idiolect from (text or file paths, repeatable)</td></tr>
+        <tr><td><code>--model</code></td><td>No</td><td><code>gpt-5-nano</code></td><td>OpenAI model to use</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>openai chat</code></td>
+          <td><code>--message</code></td>
+          <td><code>--chat-history</code> <code>--model</code></td>
+          <td>Assistant reply to stdout</td>
+        </tr>
+        <tr>
+          <td><code>openai translate</code></td>
+          <td><code>--text</code> <code>--target-language</code></td>
+          <td><code>--model</code></td>
+          <td>Translated text to stdout</td>
+        </tr>
+        <tr>
+          <td><code>openai ocaaar</code></td>
+          <td><code>--image-path</code></td>
+          <td><code>--model</code></td>
+          <td>Pirate-speak OCR result to stdout</td>
+        </tr>
+        <tr>
+          <td><code>openai corpospeak</code></td>
+          <td><code>--source</code> <code>--audience</code></td>
+          <td><code>--user-messages</code> <code>--model</code></td>
+          <td>Rewritten text to stdout</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; OpenAI Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/strings.html
+++ b/docs/strings.html
@@ -1,0 +1,516 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — Strings</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .card h3 { margin-top: 0; color: #e2e8f0; }
+    .card p { margin-bottom: 0.5rem; }
+
+    .math-block {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 1rem 1.25rem;
+      margin: 0.75rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.9rem;
+      color: #93c5fd;
+      overflow-x: auto;
+    }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .score-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+
+    .score-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.9rem;
+    }
+
+    .score-card .range {
+      font-size: 0.75rem;
+      font-weight: 700;
+      font-family: 'Courier New', monospace;
+      color: #60a5fa;
+      margin-bottom: 0.2rem;
+    }
+
+    .score-card .band {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #e2e8f0;
+      margin-bottom: 0.2rem;
+    }
+
+    .score-card p {
+      font-size: 0.8rem;
+      color: #64748b;
+      margin: 0;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Strings <span class="badge">strings</span></h1>
+  <div class="subtitle">String manipulation utilities — file reversal, edit distance, vowel stripping, and readability analysis</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk strings</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#reverse">reverse</a>
+  <a href="#levenshtein">levenshtein-distance</a>
+  <a href="#abjadify">abjadify</a>
+  <a href="#flesch">flesch-reading-ease</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- REVERSE -->
+  <section id="reverse">
+    <h2>reverse</h2>
+    <p>
+      Reads the entire content of a file and writes it back in reverse character order.
+      The reversal operates on the raw character sequence of the file — Unicode code points are preserved,
+      but byte-order marks and newline conventions are not adjusted.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk strings reverse</span>
+      <span class="opt"> --in-file</span> <span class="val">input.txt</span>
+      <span class="opt"> --out-file</span> <span class="val">reversed.txt</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    A["input.txt\n\"Hello, world!\""] --> R["Reverse\ncharacter sequence"]
+    R --> B["reversed.txt\n\"!dlrow ,olleH\""]
+      </div>
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--in-file</code></td><td>Yes</td><td>Path to the input file to reverse</td></tr>
+        <tr><td><code>--out-file</code></td><td>Yes</td><td>Path to write the reversed content</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- LEVENSHTEIN -->
+  <section id="levenshtein">
+    <h2>levenshtein-distance</h2>
+    <p>
+      Computes the Levenshtein (edit) distance between two strings: the minimum number of single-character
+      insertions, deletions, or substitutions required to transform one string into the other.
+      Each argument can be a literal string value or a file path — if a path resolves to an existing file
+      its contents are used as the string.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk strings levenshtein-distance</span>
+      <span class="opt"> --string1</span> <span class="val">"kitten"</span>
+      <span class="opt"> --string2</span> <span class="val">"sitting"</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    S1["--string1\n(literal or file path)"] --> CALC["Dynamic programming\nmatrix O(m × n)"]
+    S2["--string2\n(literal or file path)"] --> CALC
+    CALC --> OUT(["stdout: distance"])
+      </div>
+    </div>
+
+    <h3>Algorithm</h3>
+    <p>
+      The implementation uses the standard dynamic-programming approach. A matrix of size
+      <code>(m+1) × (n+1)</code> is built where each cell <code>[i][j]</code> stores the edit distance
+      between the first <code>i</code> characters of string 1 and the first <code>j</code> characters of string 2.
+    </p>
+    <div class="math-block">cost = 0 if s1[i] == s2[j], else 1
+matrix[i][j] = min(
+  matrix[i-1][j]   + 1,      // deletion
+  matrix[i][j-1]   + 1,      // insertion
+  matrix[i-1][j-1] + cost    // substitution
+)</div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--string1</code></td><td>Yes</td><td>First string or path to a file whose contents are used</td></tr>
+        <tr><td><code>--string2</code></td><td>Yes</td><td>Second string or path to a file whose contents are used</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- ABJADIFY -->
+  <section id="abjadify">
+    <h2>abjadify</h2>
+    <p>
+      Strips English vowels (<code>a e i o u</code>, upper and lower case) from every word in a file,
+      mimicking the consonant-heavy style of abjad writing systems used in Arabic, Hebrew, and related scripts.
+      Single-vowel words (<code>a</code> and <code>i</code>) are preserved intact because they would become
+      empty strings otherwise, losing meaning.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk strings abjadify</span>
+      <span class="opt"> --in-file</span> <span class="val">text.txt</span>
+      <span class="opt"> --out-file</span> <span class="val">abjadified.txt</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    IN["input.txt\n\"I like a quiet place\""] --> SPLIT["Split on\nnon-letter boundaries"]
+    SPLIT --> CHECK{"Single-vowel\nword?"}
+    CHECK -- Yes --> KEEP["Preserve as-is\n'I', 'a'"]
+    CHECK -- No --> STRIP["Remove vowels\n'like' → 'lk'\n'quiet' → 'qt'\n'place' → 'plc'"]
+    KEEP --> JOIN["Reassemble"]
+    STRIP --> JOIN
+    JOIN --> OUT["output.txt\n\"I lk a qt plc\""]
+      </div>
+    </div>
+
+    <div class="info-box">
+      Whitespace, punctuation, and non-letter characters are passed through unchanged, so the output
+      preserves the original document structure.
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--in-file</code></td><td>Yes</td><td>Path to the input plain-text file</td></tr>
+        <tr><td><code>--out-file</code></td><td>Yes</td><td>Path to write the abjadified output</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- FLESCH -->
+  <section id="flesch">
+    <h2>flesch-reading-ease</h2>
+    <p>
+      Analyses a plain-text file and produces a Flesch Reading Ease score — a well-established formula
+      that estimates how easy a passage is to read based on sentence length and word complexity (syllable count).
+      Higher scores indicate easier text; lower scores indicate more complex writing.
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk strings flesch-reading-ease</span>
+      <span class="opt"> --in-file</span> <span class="val">document.txt</span>
+    </div>
+
+    <h3>Formula</h3>
+    <div class="math-block">score = 206.835 − (1.015 × words/sentences) − (84.6 × syllables/words)</div>
+    <p>
+      The raw score is clamped to the range [0, 100]. Syllables are counted using a vowel-group heuristic:
+      each contiguous run of vowel characters (a e i o u y) counts as one syllable, with a correction for
+      silent trailing <code>-e</code>. Every word is counted as having at least one syllable.
+    </p>
+
+    <h3>Readability Bands</h3>
+    <div class="score-grid">
+      <div class="score-card">
+        <div class="range">90 – 100</div>
+        <div class="band">Very easy</div>
+        <p>Easily understood by an average 11-year-old.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">80 – 89</div>
+        <div class="band">Easy</div>
+        <p>Conversational English.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">70 – 79</div>
+        <div class="band">Fairly easy</div>
+        <p>Aimed at 13-year-old readers.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">60 – 69</div>
+        <div class="band">Standard</div>
+        <p>Plain English, easily understood.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">50 – 59</div>
+        <div class="band">Fairly difficult</div>
+        <p>Suited to high school or college level.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">30 – 49</div>
+        <div class="band">Difficult</div>
+        <p>Best understood by college graduates.</p>
+      </div>
+      <div class="score-card">
+        <div class="range">0 – 29</div>
+        <div class="band">Very confusing</div>
+        <p>Best understood by university graduates.</p>
+      </div>
+    </div>
+
+    <h3>Output</h3>
+    <p>Five values are printed to stdout:</p>
+    <div class="cmd-block">
+Flesch Reading Ease: 65.34
+Readability: Standard
+Sentences: 12
+Words: 198
+Syllables: 301
+    </div>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--in-file</code></td><td>Yes</td><td>Path to the plain-text file to analyse</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>strings reverse</code></td>
+          <td><code>--in-file</code> <code>--out-file</code></td>
+          <td>&mdash;</td>
+          <td>Reversed content written to <code>--out-file</code></td>
+        </tr>
+        <tr>
+          <td><code>strings levenshtein-distance</code></td>
+          <td><code>--string1</code> <code>--string2</code></td>
+          <td>&mdash;</td>
+          <td>Integer distance printed to stdout</td>
+        </tr>
+        <tr>
+          <td><code>strings abjadify</code></td>
+          <td><code>--in-file</code> <code>--out-file</code></td>
+          <td>&mdash;</td>
+          <td>Vowel-stripped text written to <code>--out-file</code></td>
+        </tr>
+        <tr>
+          <td><code>strings flesch-reading-ease</code></td>
+          <td><code>--in-file</code></td>
+          <td>&mdash;</td>
+          <td>Score, readability band, and counts printed to stdout</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; Strings Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/web.html
+++ b/docs/web.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixelbadger Toolkit — Web</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1117;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    header {
+      background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+      border-bottom: 1px solid #334155;
+      padding: 2rem 2.5rem;
+    }
+
+    header h1 { font-size: 1.75rem; font-weight: 700; color: #f8fafc; }
+    header .subtitle { margin-top: 0.4rem; font-size: 1rem; color: #94a3b8; }
+    header .meta { margin-top: 0.5rem; font-size: 0.85rem; color: #64748b; }
+
+    .badge {
+      display: inline-block;
+      background: #1e40af;
+      color: #bfdbfe;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0.05em;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+
+    nav {
+      background: #0f1117;
+      border-bottom: 1px solid #1e293b;
+      padding: 0.75rem 2.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    nav a:hover { color: #93c5fd; text-decoration: underline; }
+
+    .content { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+
+    section { margin-bottom: 3rem; }
+
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      margin: 1.5rem 0 0.75rem;
+    }
+
+    p { color: #94a3b8; margin-bottom: 0.75rem; }
+
+    code {
+      background: #1e293b;
+      color: #7dd3fc;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    .cmd-block {
+      background: #020617;
+      border: 1px solid #1e293b;
+      border-left: 3px solid #22d3ee;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.5rem 0;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      overflow-x: auto;
+    }
+
+    .cmd-block .prompt { color: #64748b; user-select: none; }
+    .cmd-block .cmd { color: #22d3ee; }
+    .cmd-block .opt { color: #a78bfa; }
+    .cmd-block .val { color: #86efac; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      margin: 1rem 0;
+    }
+
+    th {
+      background: #1e293b;
+      color: #cbd5e1;
+      font-weight: 600;
+      text-align: left;
+      padding: 0.6rem 0.9rem;
+      border: 1px solid #334155;
+    }
+
+    td {
+      padding: 0.55rem 0.9rem;
+      border: 1px solid #1e293b;
+      color: #94a3b8;
+      vertical-align: top;
+    }
+
+    tr:nth-child(even) td { background: #0f172a; }
+    tr:nth-child(odd) td { background: #131b2e; }
+
+    td code { font-size: 0.8rem; }
+
+    .diagram-wrap {
+      background: #131b2e;
+      border: 1px solid #1e293b;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin: 1rem 0;
+      overflow-x: auto;
+    }
+
+    .diagram-wrap .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    .info-box {
+      background: #0c2340;
+      border: 1px solid #1d4ed8;
+      border-left: 3px solid #3b82f6;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #93c5fd;
+    }
+
+    .warning-box {
+      background: #1c1008;
+      border: 1px solid #92400e;
+      border-left: 3px solid #f59e0b;
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      font-size: 0.88rem;
+      color: #fcd34d;
+    }
+
+    footer {
+      border-top: 1px solid #1e293b;
+      padding: 1.5rem 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Web <span class="badge">web</span></h1>
+  <div class="subtitle">Local web utilities — serve a single HTML file over HTTP for quick previewing</div>
+  <div class="meta">Pixelbadger Toolkit &mdash; <code>pbtk web</code> &mdash; <a href="index.html" style="color:#60a5fa">&#8592; all topics</a></div>
+</header>
+
+<nav>
+  <a href="#serve-html">serve-html</a>
+  <a href="#command-ref">Command Reference</a>
+</nav>
+
+<div class="content">
+
+  <!-- SERVE-HTML -->
+  <section id="serve-html">
+    <h2>serve-html</h2>
+    <p>
+      Starts a minimal HTTP server on a local port and serves a single HTML file. Every request to
+      the server — regardless of path — returns the specified file. This is useful for previewing
+      local HTML documents in a browser without configuring a full web server.
+    </p>
+    <p>
+      The server uses ASP.NET Core's built-in hosting stack. It runs until the process is terminated
+      (Ctrl+C).
+    </p>
+
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk web serve-html</span>
+      <span class="opt"> --file</span> <span class="val">report.html</span>
+      <span class="opt"> --port</span> <span class="val">8080</span>
+    </div>
+
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    CLI["pbtk web serve-html\n--file report.html\n--port 8080"] --> SRV["ASP.NET Core\nHTTP server\nbinds 0.0.0.0:8080"]
+    SRV --> REQ["Any HTTP request"]
+    REQ --> RESP["Return report.html\nContent-Type: text/html"]
+      </div>
+    </div>
+
+    <div class="info-box">
+      The default port is <strong>8080</strong>. If the port is already in use the server will fail to bind
+      and exit with an error. Pass a different <code>--port</code> value to use another port.
+    </div>
+
+    <div class="warning-box">
+      <strong>Local use only:</strong> the server binds on all interfaces (<code>0.0.0.0</code>).
+      Do not use this to serve sensitive files on a shared or public network.
+    </div>
+
+    <h3>Example workflow</h3>
+    <p>Serve a documentation file while keeping the server running in a terminal:</p>
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk web serve-html</span>
+      <span class="opt"> --file</span> <span class="val">docs/report.html</span>
+      <span class="opt"> --port</span> <span class="val">3000</span>
+    </div>
+    <p style="margin-top:0.5rem">Then open <code>http://localhost:3000</code> in a browser. Press <code>Ctrl+C</code> to stop the server.</p>
+
+    <table>
+      <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr><td><code>--file</code></td><td>Yes</td><td>&mdash;</td><td>Path to the HTML file to serve</td></tr>
+        <tr><td><code>--port</code></td><td>No</td><td><code>8080</code></td><td>TCP port to bind the HTTP server to</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- COMMAND REFERENCE -->
+  <section id="command-ref">
+    <h2>Command Reference</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Command</th>
+          <th>Required options</th>
+          <th>Optional options</th>
+          <th>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>web serve-html</code></td>
+          <td><code>--file</code></td>
+          <td><code>--port</code> (default 8080)</td>
+          <td>HTTP server running until Ctrl+C</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<footer>
+  Pixelbadger Toolkit &mdash; Web Documentation
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#0f172a',
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#475569',
+      secondaryColor: '#1e293b',
+      tertiaryColor: '#0f172a',
+      edgeLabelBackground: '#1e293b',
+      clusterBkg: '#1e293b',
+      titleColor: '#f1f5f9',
+      nodeTextColor: '#e2e8f0',
+    }
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #34

## Summary

- Added `docs/index.html` — index page listing all topics with descriptions and action tags, linking to each topic doc
- Added `docs/strings.html` — covers `reverse`, `levenshtein-distance`, `abjadify`, and `flesch-reading-ease` with algorithm details, Flesch readability band table, and Mermaid flow diagrams
- Added `docs/interpreters.html` — covers `brainfuck`, `ook`, and `bf-to-ook` including full instruction set tables for both Brainfuck and Ook
- Added `docs/images.html` — covers `steganography` encode/decode with LSB bit-packing explanation and capacity formula
- Added `docs/web.html` — covers `serve-html` with usage and warning about network exposure
- Added `docs/openai.html` — covers `chat`, `translate`, `ocaaar`, and `corpospeak` including the full audience slug list for corpospeak
- Added `docs/oauth.html` — covers `token` and `profile` (add/update/delete) with ROPC grant flow diagram

All pages use the same visual style as the existing `paillier-encryption.html`. The index links to the crypto doc at `paillier-encryption.html` so all topics are reachable from one place.

## Test plan

- [x] Tests pass: `dotnet test` (329 passed)
- [x] No version bump required — HTML docs in `docs/` are not NuGet-published content