### PR TITLE
Extract deterministic PR checks into bash workflow; tighten Haiku review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,28 +3,20 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,19 +29,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Review this pull request against the following checklist only. Be concise — flag issues, don't praise.
+            Review this pull request for the following only. Be concise — flag issues, don't praise.
 
-            **1. Version bump** — If any `.cs` or `.csproj` files changed outside of `*.Tests/` or `*.Benchmarks/`, the `<Version>` element in `Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj` must be incremented. Flag if missing.
-
-            **2. Tests present** — Any new component class or command action must have a corresponding `*Tests.cs` file. Flag any new `Components/` or `Commands/` files without matching tests.
-
-            **3. Benchmarks updated** — If the diff touches `LevenshteinCalculator`, `BrainfuckInterpreter`, `OokInterpreter`, `AbjadifyComponent`, `ImageSteganography`, or `HomomorphicEncryptionComponent`, a corresponding benchmark file in `Pixelbadger.Toolkit.Benchmarks/` must also be updated. Flag if missing.
-
-            **4. Sanity check** — Flag obvious bugs, unhandled nulls in critical paths, prompt injection risks (user-controlled strings passed directly to LLMs), or path traversal in file operations.
+            **Sanity check** — Flag:
+            - Obvious bugs or logic errors
+            - Unhandled nulls in critical paths
+            - Prompt injection risk: user-controlled strings passed directly into LLM calls without sanitisation
+            - Path traversal: user-supplied file paths used in file operations without validation
 
             Once you have completed the review, submit a formal GitHub review using `gh pr review`:
-            - If all checks pass: `gh pr review <PR_NUMBER> --approve --body "LGTM — all checks passed."`
-            - If any check fails: `gh pr review <PR_NUMBER> --request-changes --body "<summary of issues found>"`
+            - If no issues found: `gh pr review <PR_NUMBER> --approve --body "LGTM — no sanity-check issues found."`
+            - If issues found: `gh pr review <PR_NUMBER> --request-changes --body "<summary of issues found>"`
 
-          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"'
+          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 15 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"'
 

--- a/.github/workflows/pr-mechanical-checks.yml
+++ b/.github/workflows/pr-mechanical-checks.yml
@@ -1,0 +1,120 @@
+name: PR Mechanical Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  mechanical-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        id: version-bump
+        run: |
+          FAILED=false
+
+          # Files changed vs master, excluding tests and benchmarks
+          PROD_CHANGES=$(git diff origin/master...HEAD --name-only | grep -E '\.(cs|csproj)$' | grep -vE '^Pixelbadger\.Toolkit\.(Tests|Benchmarks)/' || true)
+
+          if [ -n "$PROD_CHANGES" ]; then
+            # csproj must appear in the diff
+            CSPROJ_IN_DIFF=$(git diff origin/master...HEAD --name-only | grep 'Pixelbadger\.Toolkit/Pixelbadger\.Toolkit\.csproj' || true)
+            if [ -z "$CSPROJ_IN_DIFF" ]; then
+              echo "::error::Version bump required: production .cs/.csproj files changed but Pixelbadger.Toolkit.csproj is not in the diff."
+              FAILED=true
+            else
+              # Compare version on this branch vs master
+              BRANCH_VERSION=$(grep -oP '(?<=<Version>)[^<]+' Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj)
+              MASTER_VERSION=$(git show origin/master:Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj | grep -oP '(?<=<Version>)[^<]+')
+              HIGHER=$(printf '%s\n%s\n' "$MASTER_VERSION" "$BRANCH_VERSION" | sort -V | tail -1)
+              if [ "$HIGHER" = "$MASTER_VERSION" ] || [ "$BRANCH_VERSION" = "$MASTER_VERSION" ]; then
+                echo "::error::Version bump required: branch version ($BRANCH_VERSION) is not strictly higher than master ($MASTER_VERSION)."
+                FAILED=true
+              else
+                echo "Version bump OK: $MASTER_VERSION -> $BRANCH_VERSION"
+              fi
+            fi
+          else
+            echo "No production code changes — version bump not required."
+          fi
+
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+
+      - name: Check tests present
+        id: tests-present
+        run: |
+          FAILED=false
+
+          # Newly added files under Components/ or Commands/
+          NEW_IMPL=$(git diff origin/master...HEAD --diff-filter=A --name-only | grep -E '^Pixelbadger\.Toolkit/(Components|Commands)/[^/]+\.cs$' || true)
+
+          for FILE in $NEW_IMPL; do
+            BASENAME=$(basename "$FILE" .cs)
+            EXPECTED="${BASENAME}Tests.cs"
+            MATCH=$(find Pixelbadger.Toolkit.Tests -name "$EXPECTED" 2>/dev/null || true)
+            if [ -z "$MATCH" ]; then
+              echo "::error::Missing test file: no $EXPECTED found under Pixelbadger.Toolkit.Tests/ for new file $FILE."
+              FAILED=true
+            else
+              echo "Test coverage OK: $EXPECTED exists for $FILE"
+            fi
+          done
+
+          if [ -z "$NEW_IMPL" ]; then
+            echo "No new Components/ or Commands/ files — test presence check skipped."
+          fi
+
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+
+      - name: Check benchmarks updated
+        id: benchmarks-updated
+        run: |
+          FAILED=false
+
+          WATCHLIST=(
+            "LevenshteinCalculator"
+            "BrainfuckInterpreter"
+            "OokInterpreter"
+            "AbjadifyComponent"
+            "ImageSteganography"
+            "HomomorphicEncryptionComponent"
+          )
+
+          CHANGED_BASENAMES=$(git diff origin/master...HEAD --name-only | xargs -I{} basename {} .cs)
+
+          for ENTRY in "${WATCHLIST[@]}"; do
+            if echo "$CHANGED_BASENAMES" | grep -qx "$ENTRY"; then
+              # Check if any benchmark file referencing this entry is also in the diff
+              BENCHMARK_REFS=$(git diff origin/master...HEAD --name-only | grep -E '^Pixelbadger\.Toolkit\.Benchmarks/' || true)
+              FOUND=false
+              for BF in $BENCHMARK_REFS; do
+                if grep -q "$ENTRY" "$BF" 2>/dev/null; then
+                  FOUND=true
+                  break
+                fi
+              done
+              if [ "$FOUND" = false ]; then
+                echo "::error::Benchmark update required: $ENTRY was changed but no benchmark file under Pixelbadger.Toolkit.Benchmarks/ referencing it appears in the diff."
+                FAILED=true
+              else
+                echo "Benchmark OK: $ENTRY has a corresponding benchmark update."
+              fi
+            fi
+          done
+
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any check failed
+        if: steps.version-bump.outputs.failed == 'true' || steps.tests-present.outputs.failed == 'true' || steps.benchmarks-updated.outputs.failed == 'true'
+        run: |
+          echo "One or more mechanical checks failed. See ::error:: annotations above."
+          exit 1


### PR DESCRIPTION
## Summary

- **New**: `.github/workflows/pr-mechanical-checks.yml` — three deterministic checks (version bump, tests present, benchmarks updated) run as plain bash steps with no model invocation. All three steps always run; failures are collected via `::error::` annotations and the job fails at the end if any step failed.
- **Modified**: `.github/workflows/claude-code-review.yml` — prompt narrowed to sanity-check only (obvious bugs, unhandled nulls, prompt injection, path traversal); `--max-turns 15` added to `claude_args`; top-level `concurrency` block added to cancel in-progress runs on re-push.

No production code changed; version bump not required per CLAUDE.md.

## Test plan
- [ ] Mental scenario: only test files changed → version check passes (no prod code touched)
- [ ] Mental scenario: new `Components/FooComponent.cs` with no `FooComponentTests.cs` → tests-present check fails with `::error::` annotation
- [ ] Mental scenario: `LevenshteinCalculator.cs` modified, no benchmark diff → benchmarks-updated check fails with `::error::` annotation
- [ ] Both YAML files are syntactically valid (no actionlint available locally; visually reviewed)