### PR TITLE
Add gpt topic: from-scratch char-level GPT trainer/completer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,3 +485,7 @@ $RECYCLE.BIN/
 
 # Test assets and temporary files
 test-assets/
+
+# GPT/Markov model checkpoint directories
+.gpt/
+.Markov/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ The project is .NET 9, and uses Microsoft's System.CommandLine library for build
   - `pbtk llm ocaaar --image-path ./image.jpg`
   - `pbtk llm corpospeak --source "API performance is great" --audience "csuite"`
   - `pbtk llm corpospeak --source "New feature deployed" --audience "engineering" --user-messages "Hey team" "Let's ship this"`
+  - `pbtk gpt train --source corpus.txt --out ./.gpt --steps 2000`
+  - `pbtk gpt complete --model ./.gpt --prompt "ROMEO:" --max-tokens 200`
 
 ### Testing Requirements
 
@@ -251,6 +253,7 @@ Available topics and actions:
 - **images**: steganography
 - **web**: serve-html
 - **llm**: chat, translate, ocaaar, corpospeak
+- **gpt**: train, complete
 
 ## Dependencies
 

--- a/Pixelbadger.Toolkit.Tests/AdamWTests.cs
+++ b/Pixelbadger.Toolkit.Tests/AdamWTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class AdamWTests
+{
+    [Fact]
+    public void Step_ShouldApplyExpectedAdamUpdate_OnFirstStep()
+    {
+        var p = Tensor.FromData(1, 1, new[] { 1.0f }, requiresGrad: true);
+        p.Grad[0] = 0.5f;
+
+        var optimizer = new AdamW([p], lr: 0.1f, beta1: 0.9f, beta2: 0.95f, eps: 1e-8f, weightDecay: 0.1f);
+        optimizer.Step();
+
+        // m=0.05, v=0.0125; bias-corrected mHat=0.5, vHat=0.25 -> step = lr*(0.1*1 + 0.5/0.5) = 0.11
+        p.Data[0].Should().BeApproximately(0.89f, 1e-5f);
+    }
+
+    [Fact]
+    public void Step_ShouldApplyWeightDecay_WhenGradientIsZero()
+    {
+        var p = Tensor.FromData(1, 1, new[] { 2.0f }, requiresGrad: true);
+        p.Grad[0] = 0f;
+
+        var optimizer = new AdamW([p], lr: 0.1f, weightDecay: 0.1f);
+        optimizer.Step();
+
+        // Only decoupled weight decay applies: 2 - 0.1*0.1*2 = 1.98
+        p.Data[0].Should().BeApproximately(1.98f, 1e-5f);
+    }
+
+    [Fact]
+    public void Step_ShouldMoveParameterAgainstGradientDirection()
+    {
+        var p = Tensor.FromData(1, 1, new[] { 0.0f }, requiresGrad: true);
+        p.Grad[0] = 1.0f;
+
+        var optimizer = new AdamW([p], lr: 0.1f, weightDecay: 0f);
+        optimizer.Step();
+
+        p.Data[0].Should().BeLessThan(0f);
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/CharTokenizerTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CharTokenizerTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class CharTokenizerTests
+{
+    [Fact]
+    public void Build_ShouldCreateSortedDistinctVocabulary()
+    {
+        var tokenizer = CharTokenizer.Build("banana");
+
+        tokenizer.VocabSize.Should().Be(3);
+        tokenizer.Vocabulary.Should().Equal('a', 'b', 'n');
+    }
+
+    [Fact]
+    public void EncodeDecode_ShouldRoundTrip()
+    {
+        var tokenizer = CharTokenizer.Build("hello world");
+
+        var ids = tokenizer.Encode("hello world");
+        var text = tokenizer.Decode(ids);
+
+        text.Should().Be("hello world");
+    }
+
+    [Fact]
+    public void Encode_ShouldThrow_WhenCharacterNotInVocabulary()
+    {
+        var tokenizer = CharTokenizer.Build("abc");
+
+        var act = () => tokenizer.Encode("abz");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not present*");
+    }
+
+    [Fact]
+    public void Build_ShouldThrow_WhenCorpusIsEmpty()
+    {
+        var act = () => CharTokenizer.Build("");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void FromVocabulary_ShouldPreserveOrderingForDeterministicIds()
+    {
+        var tokenizer = CharTokenizer.FromVocabulary(new[] { 'x', 'y', 'z' });
+
+        tokenizer.Encode("zxy").Should().Equal(2, 0, 1);
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/CheckpointServiceTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CheckpointServiceTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class CheckpointServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly CheckpointService _service = new();
+
+    public CheckpointServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+            Directory.Delete(_testDirectory, true);
+    }
+
+    [Fact]
+    public async Task SaveThenLoad_ShouldRoundTripConfigVocabularyAndWeights()
+    {
+        var config = new GptConfig(VocabSize: 6, BlockSize: 4, NEmbd: 8, NHead: 2, NLayer: 1);
+        var model = new GptModel(config);
+        model.InitWeights(123);
+        var vocab = new[] { 'a', 'b', 'c', 'd', 'e', 'f' };
+        var dir = Path.Combine(_testDirectory, "ckpt");
+
+        await _service.SaveAsync(dir, config, vocab, model.Parameters());
+        var loaded = await _service.LoadAsync(dir);
+
+        loaded.Config.Should().Be(config);
+        loaded.Vocabulary.Should().Equal(vocab);
+        loaded.Weights.Length.Should().Be(model.Parameters().Count);
+        for (int i = 0; i < loaded.Weights.Length; i++)
+            loaded.Weights[i].Should().Equal(model.Parameters()[i].Data);
+    }
+
+    [Fact]
+    public async Task LoadedWeights_ShouldReproduceIdenticalForwardPass()
+    {
+        var config = new GptConfig(VocabSize: 6, BlockSize: 4, NEmbd: 8, NHead: 2, NLayer: 1);
+        var original = new GptModel(config);
+        original.InitWeights(7);
+        var vocab = new[] { 'a', 'b', 'c', 'd', 'e', 'f' };
+        var dir = Path.Combine(_testDirectory, "ckpt");
+        await _service.SaveAsync(dir, config, vocab, original.Parameters());
+
+        var loaded = await _service.LoadAsync(dir);
+        var restored = new GptModel(loaded.Config);
+        restored.LoadWeights(loaded.Weights);
+
+        var batch = new[] { new[] { 1, 2, 3, 0 } };
+        var (originalLogits, _) = original.Forward(batch);
+        var (restoredLogits, _) = restored.Forward(batch);
+
+        restoredLogits.Data.Should().Equal(originalLogits.Data);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ShouldThrow_WhenCheckpointMissing()
+    {
+        var act = async () => await _service.LoadAsync(Path.Combine(_testDirectory, "does-not-exist"));
+
+        await act.Should().ThrowAsync<FileNotFoundException>().WithMessage("*gpt train*");
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/GptCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptCommandIntegrationTests.cs
@@ -1,0 +1,60 @@
+using System.CommandLine;
+using FluentAssertions;
+using Pixelbadger.Toolkit.Commands;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class GptCommandIntegrationTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public GptCommandIntegrationTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+            Directory.Delete(_testDirectory, true);
+    }
+
+    [Fact]
+    public async Task GptCommand_ShouldTrainCheckpointThenGenerateText()
+    {
+        var corpusPath = Path.Combine(_testDirectory, "corpus.txt");
+        await File.WriteAllTextAsync(corpusPath, string.Concat(Enumerable.Repeat("hello gpt world. ", 30)));
+        var modelDir = Path.Combine(_testDirectory, "model");
+
+        var trainExit = await GptCommand.Create().Parse(new[]
+        {
+            "train",
+            "--source", corpusPath,
+            "--out", modelDir,
+            "--steps", "5",
+            "--batch-size", "4",
+            "--block-size", "8",
+            "--n-embd", "16",
+            "--n-head", "2",
+            "--n-layer", "1",
+            "--seed", "1"
+        }).InvokeAsync();
+
+        trainExit.Should().Be(0);
+        File.Exists(Path.Combine(modelDir, "config.json")).Should().BeTrue();
+        File.Exists(Path.Combine(modelDir, "weights.bin")).Should().BeTrue();
+
+        // complete must load the freshly-written checkpoint and generate without error.
+        var completeExit = await GptCommand.Create().Parse(new[]
+        {
+            "complete",
+            "--model", modelDir,
+            "--prompt", "hello",
+            "--max-tokens", "10",
+            "--temperature", "0"
+        }).InvokeAsync();
+
+        completeExit.Should().Be(0);
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/GptCompleteComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptCompleteComponentTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Moq;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class GptCompleteComponentTests
+{
+    private readonly Mock<ICheckpointService> _mockCheckpoint = new();
+    private readonly GptCompleteComponent _component;
+
+    public GptCompleteComponentTests()
+    {
+        _component = new GptCompleteComponent(_mockCheckpoint.Object);
+    }
+
+    private void SetupCheckpoint(GptConfig config, char[] vocab, int seed)
+    {
+        var model = new GptModel(config);
+        model.InitWeights(seed);
+        var weights = model.Parameters().Select(p => (float[])p.Data.Clone()).ToArray();
+        _mockCheckpoint.Setup(x => x.LoadAsync(It.IsAny<string>()))
+            .ReturnsAsync(new GptCheckpoint(config, vocab, weights));
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ShouldBeDeterministic_WithGreedyDecoding()
+    {
+        var config = new GptConfig(VocabSize: 6, BlockSize: 4, NEmbd: 8, NHead: 2, NLayer: 1);
+        SetupCheckpoint(config, "abcdef".ToCharArray(), seed: 5);
+
+        var first = await _component.CompleteAsync("model", "abc", maxTokens: 20, temperature: 0f, seed: 1);
+        var second = await _component.CompleteAsync("model", "abc", maxTokens: 20, temperature: 0f, seed: 99);
+
+        first.Text.Should().Be(second.Text, "greedy decoding ignores the seed and is fully deterministic");
+        first.Text.Length.Should().Be(3 + 20); // prompt + generated
+        first.Text.Should().StartWith("abc");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ShouldCropContextToBlockSize()
+    {
+        var config = new GptConfig(VocabSize: 6, BlockSize: 4, NEmbd: 8, NHead: 2, NLayer: 1);
+        SetupCheckpoint(config, "abcdef".ToCharArray(), seed: 5);
+
+        // Prompt longer than the block size must not throw and should still extend the text.
+        var result = await _component.CompleteAsync("model", "abcdef", maxTokens: 5, temperature: 0f, seed: 1);
+
+        result.Text.Length.Should().Be(6 + 5);
+    }
+
+    [Fact]
+    public void ArgMax_ShouldReturnIndexOfLargestValue()
+    {
+        GptCompleteComponent.ArgMax(new[] { 0.1f, 0.9f, 0.3f, 0.2f }).Should().Be(1);
+    }
+
+    [Fact]
+    public void SampleWithTemperature_ShouldBeReproducibleForFixedSeed()
+    {
+        var logits = new[] { 1.0f, 2.0f, 0.5f, -1.0f };
+
+        var a = GptCompleteComponent.SampleWithTemperature(logits, 0.8f, new Random(7));
+        var b = GptCompleteComponent.SampleWithTemperature(logits, 0.8f, new Random(7));
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void SampleWithTemperature_ShouldAlwaysSelectDominantLogit()
+    {
+        // One logit overwhelmingly larger -> probability mass collapses onto it.
+        var logits = new[] { -50f, 50f, -50f };
+
+        for (int seed = 0; seed < 10; seed++)
+            GptCompleteComponent.SampleWithTemperature(logits, 1.0f, new Random(seed)).Should().Be(1);
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/GptModelTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptModelTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class GptModelTests
+{
+    private static GptConfig SmallConfig() => new(VocabSize: 8, BlockSize: 4, NEmbd: 8, NHead: 2, NLayer: 2);
+
+    [Fact]
+    public void Forward_ShouldProduceLogitsWithExpectedShape()
+    {
+        var model = new GptModel(SmallConfig());
+        model.InitWeights(0);
+
+        var batch = new[]
+        {
+            new[] { 1, 2, 3, 0 },
+            new[] { 4, 5, 6, 7 }
+        };
+
+        var (logits, loss) = model.Forward(batch);
+
+        logits.Rows.Should().Be(8); // batch(2) * block(4)
+        logits.Cols.Should().Be(8); // vocab
+        loss.Should().BeNull();
+    }
+
+    [Fact]
+    public void Forward_ShouldReturnFinitePositiveLoss_WhenTargetsProvided()
+    {
+        var model = new GptModel(SmallConfig());
+        model.InitWeights(0);
+
+        var batch = new[] { new[] { 1, 2, 3, 0 } };
+        var targets = new[] { new[] { 2, 3, 0, 1 } };
+
+        var (_, loss) = model.Forward(batch, targets);
+
+        loss.Should().NotBeNull();
+        float value = loss!.Data[0];
+        float.IsFinite(value).Should().BeTrue();
+        value.Should().BeGreaterThan(0f);
+    }
+
+    [Fact]
+    public void ParameterCount_ShouldMatchClosedFormForConfig()
+    {
+        var model = new GptModel(SmallConfig());
+
+        // V*C + block*C + L*(12C^2 + 13C) + 2C, with V=8,C=8,block=4,L=2.
+        model.ParameterCount().Should().Be(1856);
+    }
+
+    [Fact]
+    public void InitWeights_ShouldBeDeterministicForFixedSeed()
+    {
+        var a = new GptModel(SmallConfig());
+        a.InitWeights(42);
+        var b = new GptModel(SmallConfig());
+        b.InitWeights(42);
+
+        var pa = a.Parameters();
+        var pb = b.Parameters();
+        for (int i = 0; i < pa.Count; i++)
+            pa[i].Data.Should().Equal(pb[i].Data);
+    }
+
+    [Fact]
+    public void LoadWeights_ShouldThrow_WhenCountMismatched()
+    {
+        var model = new GptModel(SmallConfig());
+
+        var act = () => model.LoadWeights(new[] { new float[1] });
+
+        act.Should().Throw<ArgumentException>().WithMessage("*weight tensors*");
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/GptTrainComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptTrainComponentTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Moq;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class GptTrainComponentTests
+{
+    private readonly Mock<ICheckpointService> _mockCheckpoint = new();
+    private readonly GptTrainComponent _component;
+
+    public GptTrainComponentTests()
+    {
+        _component = new GptTrainComponent(_mockCheckpoint.Object);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldDriveLossDownOnRepetitiveCorpus()
+    {
+        // A highly repetitive corpus is easy to overfit, giving a deterministic, sharp pass/fail.
+        var corpus = string.Concat(Enumerable.Repeat("the quick brown fox. ", 30));
+        var options = new GptTrainOptions(
+            Steps: 200, BatchSize: 8, BlockSize: 16, NEmbd: 32, NHead: 4, NLayer: 2, LearningRate: 3e-3f, Seed: 1337);
+
+        var losses = new List<float>();
+        var result = await _component.TrainAsync(corpus, "ignored", options, (_, loss) => losses.Add(loss));
+
+        float firstLoss = losses[0];
+        float finalLoss = result.FinalLoss;
+
+        firstLoss.Should().BeGreaterThan(finalLoss, "training should reduce the loss");
+        finalLoss.Should().BeLessThan(1.0f, "the model should overfit this tiny repetitive corpus");
+        result.Steps.Should().Be(200);
+        result.ParameterCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldSaveCheckpointWithModelParameters()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+        var options = new GptTrainOptions(Steps: 3, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 1);
+
+        await _component.TrainAsync(corpus, "out-dir", options);
+
+        _mockCheckpoint.Verify(x => x.SaveAsync(
+            "out-dir",
+            It.IsAny<GptConfig>(),
+            It.IsAny<IReadOnlyList<char>>(),
+            It.IsAny<IReadOnlyList<Tensor>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldThrow_WhenEmbeddingNotDivisibleByHeads()
+    {
+        var options = new GptTrainOptions(NEmbd: 10, NHead: 4, BlockSize: 4);
+
+        var act = async () => await _component.TrainAsync("aaaa bbbb cccc", "out", options);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*divisible*");
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldThrow_WhenCorpusShorterThanBlockSize()
+    {
+        var options = new GptTrainOptions(BlockSize: 64);
+
+        var act = async () => await _component.TrainAsync("short", "out", options);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*too short*");
+    }
+
+    [Fact]
+    public void SampleBatch_ShouldProduceTargetsShiftedByOne()
+    {
+        var data = Enumerable.Range(0, 20).ToArray();
+        var rng = new Random(0);
+
+        var (inputs, targets) = GptTrainComponent.SampleBatch(data, batchSize: 3, blockSize: 4, rng);
+
+        inputs.Should().HaveCount(3);
+        targets.Should().HaveCount(3);
+        for (int b = 0; b < 3; b++)
+        {
+            inputs[b].Should().HaveCount(4);
+            for (int t = 0; t < 4; t++)
+                targets[b][t].Should().Be(inputs[b][t] + 1); // data is the identity sequence
+        }
+    }
+}

--- a/Pixelbadger.Toolkit.Tests/TensorTests.cs
+++ b/Pixelbadger.Toolkit.Tests/TensorTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+/// <summary>
+/// Validates the hand-rolled autograd engine. Each primitive op is checked by comparing its
+/// analytic gradient against a central finite-difference approximation of L = sum(g .* output)
+/// for a fixed random upstream gradient g.
+/// </summary>
+public class TensorTests
+{
+    private static Tensor RandomTensor(int rows, int cols, Random rng, float scale = 1f)
+    {
+        var t = new Tensor(rows, cols, requiresGrad: true);
+        for (int i = 0; i < t.Length; i++)
+            t.Data[i] = (float)(rng.NextDouble() * 2 - 1) * scale;
+        return t;
+    }
+
+    private static float[] RandomArray(int n, Random rng)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++)
+            a[i] = (float)(rng.NextDouble() * 2 - 1);
+        return a;
+    }
+
+    private static float Dot(float[] a, float[] b)
+    {
+        float s = 0f;
+        for (int i = 0; i < a.Length; i++)
+            s += a[i] * b[i];
+        return s;
+    }
+
+    private static void AssertClose(float analytic, float numeric)
+    {
+        float diff = MathF.Abs(analytic - numeric);
+        float bound = 3e-2f + 3e-2f * MathF.Abs(numeric);
+        diff.Should().BeLessThanOrEqualTo(bound, "analytic {0} vs numeric {1}", analytic, numeric);
+    }
+
+    private static void GradCheckOp(Tensor[] inputs, Func<Tensor> build, Random rng)
+    {
+        var output = build();
+        var g = RandomArray(output.Length, rng);
+
+        foreach (var inp in inputs)
+            inp.ZeroGrad();
+        Array.Clear(output.Grad, 0, output.Grad.Length);
+        Array.Copy(g, output.Grad, g.Length);
+        output.BackwardFn!.Invoke();
+
+        const float eps = 1e-2f;
+        foreach (var inp in inputs)
+        {
+            var analytic = (float[])inp.Grad.Clone();
+            for (int j = 0; j < inp.Length; j++)
+            {
+                float orig = inp.Data[j];
+                inp.Data[j] = orig + eps;
+                float lp = Dot(build().Data, g);
+                inp.Data[j] = orig - eps;
+                float lm = Dot(build().Data, g);
+                inp.Data[j] = orig;
+                float num = (lp - lm) / (2 * eps);
+                AssertClose(analytic[j], num);
+            }
+        }
+    }
+
+    [Fact]
+    public void MatMul_ShouldComputeCorrectForwardAndGradients()
+    {
+        var rng = new Random(1);
+        var a = RandomTensor(2, 3, rng);
+        var b = RandomTensor(3, 4, rng);
+
+        var y = Tensor.MatMul(a, b);
+        y.Rows.Should().Be(2);
+        y.Cols.Should().Be(4);
+
+        // Spot-check one forward element.
+        float expected00 = a.Data[0] * b.Data[0] + a.Data[1] * b.Data[4] + a.Data[2] * b.Data[8];
+        y.Data[0].Should().BeApproximately(expected00, 1e-5f);
+
+        GradCheckOp([a, b], () => Tensor.MatMul(a, b), rng);
+    }
+
+    [Fact]
+    public void AddBias_ShouldGradientCheck()
+    {
+        var rng = new Random(2);
+        var x = RandomTensor(3, 4, rng);
+        var bias = RandomTensor(1, 4, rng);
+        GradCheckOp([x, bias], () => Tensor.AddBias(x, bias), rng);
+    }
+
+    [Fact]
+    public void Add_ShouldGradientCheck()
+    {
+        var rng = new Random(3);
+        var a = RandomTensor(3, 4, rng);
+        var b = RandomTensor(3, 4, rng);
+        GradCheckOp([a, b], () => Tensor.Add(a, b), rng);
+    }
+
+    [Fact]
+    public void Scale_ShouldGradientCheck()
+    {
+        var rng = new Random(4);
+        var x = RandomTensor(3, 4, rng);
+        GradCheckOp([x], () => Tensor.Scale(x, 1.7f), rng);
+    }
+
+    [Fact]
+    public void Transpose_ShouldGradientCheck()
+    {
+        var rng = new Random(5);
+        var x = RandomTensor(2, 3, rng);
+        GradCheckOp([x], () => Tensor.Transpose(x), rng);
+    }
+
+    [Fact]
+    public void SoftmaxRows_ShouldGradientCheckAndSumToOne()
+    {
+        var rng = new Random(6);
+        var x = RandomTensor(3, 5, rng);
+
+        var y = Tensor.SoftmaxRows(x);
+        for (int i = 0; i < 3; i++)
+        {
+            float sum = 0f;
+            for (int j = 0; j < 5; j++)
+                sum += y.Data[i * 5 + j];
+            sum.Should().BeApproximately(1f, 1e-5f);
+        }
+
+        GradCheckOp([x], () => Tensor.SoftmaxRows(x), rng);
+    }
+
+    [Fact]
+    public void LayerNorm_ShouldGradientCheck()
+    {
+        var rng = new Random(7);
+        var x = RandomTensor(3, 6, rng);
+        var gamma = RandomTensor(1, 6, rng);
+        var beta = RandomTensor(1, 6, rng);
+        GradCheckOp([x, gamma, beta], () => Tensor.LayerNorm(x, gamma, beta), rng);
+    }
+
+    [Fact]
+    public void Gelu_ShouldGradientCheck()
+    {
+        var rng = new Random(8);
+        var x = RandomTensor(3, 4, rng, scale: 2f);
+        GradCheckOp([x], () => Tensor.Gelu(x), rng);
+    }
+
+    [Fact]
+    public void Gather_ShouldGradientCheckWithRepeatedIds()
+    {
+        var rng = new Random(9);
+        var table = RandomTensor(5, 3, rng);
+        var ids = new[] { 0, 2, 2, 1 };
+        GradCheckOp([table], () => Tensor.Gather(table, ids), rng);
+    }
+
+    [Fact]
+    public void SliceRows_ShouldGradientCheck()
+    {
+        var rng = new Random(10);
+        var x = RandomTensor(5, 3, rng);
+        GradCheckOp([x], () => Tensor.SliceRows(x, 1, 3), rng);
+    }
+
+    [Fact]
+    public void SliceCols_ShouldGradientCheck()
+    {
+        var rng = new Random(11);
+        var x = RandomTensor(4, 6, rng);
+        GradCheckOp([x], () => Tensor.SliceCols(x, 2, 3), rng);
+    }
+
+    [Fact]
+    public void ConcatCols_ShouldGradientCheck()
+    {
+        var rng = new Random(12);
+        var a = RandomTensor(3, 2, rng);
+        var b = RandomTensor(3, 4, rng);
+        GradCheckOp([a, b], () => Tensor.ConcatCols([a, b]), rng);
+    }
+
+    [Fact]
+    public void ConcatRows_ShouldGradientCheck()
+    {
+        var rng = new Random(13);
+        var a = RandomTensor(2, 3, rng);
+        var b = RandomTensor(4, 3, rng);
+        GradCheckOp([a, b], () => Tensor.ConcatRows([a, b]), rng);
+    }
+
+    [Fact]
+    public void CrossEntropy_ShouldGradientCheck()
+    {
+        var rng = new Random(14);
+        var logits = RandomTensor(4, 3, rng);
+        var targets = new[] { 0, 2, 1, 2 };
+        GradCheckOp([logits], () => Tensor.CrossEntropy(logits, targets), rng);
+    }
+
+    [Fact]
+    public void CausalMask_ShouldZeroFutureAndRouteGradientsToPast()
+    {
+        var rng = new Random(15);
+        var scores = RandomTensor(3, 3, rng);
+
+        var masked = Tensor.CausalMask(scores);
+        // Future positions (j > i) are filled with a large negative value.
+        masked.Data[0 * 3 + 1].Should().Be(-1e9f);
+        masked.Data[0 * 3 + 2].Should().Be(-1e9f);
+        masked.Data[1 * 3 + 2].Should().Be(-1e9f);
+        // Past/current positions are passed through unchanged.
+        masked.Data[2 * 3 + 0].Should().Be(scores.Data[2 * 3 + 0]);
+
+        Array.Fill(masked.Grad, 1f);
+        masked.BackwardFn!.Invoke();
+        // Lower triangle receives gradient 1, upper triangle receives 0.
+        scores.Grad[2 * 3 + 0].Should().Be(1f);
+        scores.Grad[0 * 3 + 1].Should().Be(0f);
+        scores.Grad[1 * 3 + 2].Should().Be(0f);
+    }
+
+    [Fact]
+    public void Backward_ShouldAccumulateGradientsThroughSharedInput()
+    {
+        var rng = new Random(16);
+        var x = RandomTensor(2, 2, rng);
+
+        // y = 2x + 3x = 5x, so dy/dx = 5 for every element.
+        var y = Tensor.Add(Tensor.Scale(x, 2f), Tensor.Scale(x, 3f));
+        y.Backward();
+
+        foreach (var grad in x.Grad)
+            grad.Should().BeApproximately(5f, 1e-5f);
+    }
+}

--- a/Pixelbadger.Toolkit/Commands/GptCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/GptCommand.cs
@@ -1,0 +1,135 @@
+using System.CommandLine;
+using Pixelbadger.Toolkit.Components;
+using Pixelbadger.Toolkit.Services;
+using Spectre.Console;
+
+namespace Pixelbadger.Toolkit.Commands;
+
+public static class GptCommand
+{
+    private const string DefaultModelDir = "./.gpt";
+
+    public static Command Create()
+    {
+        var command = new Command("gpt", "Train and sample from a tiny from-scratch char-level GPT");
+
+        command.Add(CreateTrainCommand());
+        command.Add(CreateCompleteCommand());
+
+        return command;
+    }
+
+    /// <summary>Returns the file contents when <paramref name="input"/> is an existing path, otherwise the literal text.</summary>
+    internal static async Task<string> ResolveTextOrFilePath(string input)
+    {
+        var resolvedPath = Path.GetFullPath(input);
+        if (File.Exists(resolvedPath))
+            return await File.ReadAllTextAsync(resolvedPath);
+        return input;
+    }
+
+    private static Command CreateTrainCommand()
+    {
+        var command = new Command("train", "Train a char-level GPT on a text corpus and save a checkpoint");
+
+        var sourceOption = new Option<string>("--source") { Description = "Path to a training corpus file (or literal text)", Required = true };
+        var outOption = new Option<string>("--out") { Description = "Checkpoint output directory", DefaultValueFactory = _ => DefaultModelDir };
+        var stepsOption = new Option<int>("--steps") { Description = "Number of training steps", DefaultValueFactory = _ => 2000 };
+        var batchSizeOption = new Option<int>("--batch-size") { Description = "Sequences per training step", DefaultValueFactory = _ => 16 };
+        var blockSizeOption = new Option<int>("--block-size") { Description = "Context length in characters", DefaultValueFactory = _ => 64 };
+        var nEmbdOption = new Option<int>("--n-embd") { Description = "Embedding dimension", DefaultValueFactory = _ => 128 };
+        var nHeadOption = new Option<int>("--n-head") { Description = "Number of attention heads", DefaultValueFactory = _ => 4 };
+        var nLayerOption = new Option<int>("--n-layer") { Description = "Number of transformer blocks", DefaultValueFactory = _ => 3 };
+        var lrOption = new Option<float>("--lr") { Description = "Learning rate", DefaultValueFactory = _ => 3e-4f };
+        var seedOption = new Option<int>("--seed") { Description = "Random seed for reproducible runs", DefaultValueFactory = _ => 1337 };
+
+        command.Add(sourceOption);
+        command.Add(outOption);
+        command.Add(stepsOption);
+        command.Add(batchSizeOption);
+        command.Add(blockSizeOption);
+        command.Add(nEmbdOption);
+        command.Add(nHeadOption);
+        command.Add(nLayerOption);
+        command.Add(lrOption);
+        command.Add(seedOption);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            try
+            {
+                var source = parseResult.GetValue(sourceOption)!;
+                var outDir = parseResult.GetValue(outOption)!;
+                var options = new GptTrainOptions(
+                    Steps: parseResult.GetValue(stepsOption),
+                    BatchSize: parseResult.GetValue(batchSizeOption),
+                    BlockSize: parseResult.GetValue(blockSizeOption),
+                    NEmbd: parseResult.GetValue(nEmbdOption),
+                    NHead: parseResult.GetValue(nHeadOption),
+                    NLayer: parseResult.GetValue(nLayerOption),
+                    LearningRate: parseResult.GetValue(lrOption),
+                    Seed: parseResult.GetValue(seedOption));
+
+                var corpus = await ResolveTextOrFilePath(source);
+
+                var component = new GptTrainComponent(new CheckpointService());
+                var result = await component.TrainAsync(corpus, outDir, options, (step, loss) =>
+                {
+                    if (step == 1 || step % 100 == 0 || step == options.Steps)
+                        AnsiConsole.MarkupLine($"[grey]step[/] {step}/{options.Steps}  [yellow]loss[/] {loss:F4}");
+                });
+
+                AnsiConsole.MarkupLine(
+                    $"[green]Trained[/] {result.ParameterCount:N0} params (vocab {result.VocabSize}) — final loss {result.FinalLoss:F4}. Checkpoint: {Markup.Escape(result.CheckpointPath)}");
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                Environment.Exit(1);
+            }
+        });
+
+        return command;
+    }
+
+    private static Command CreateCompleteCommand()
+    {
+        var command = new Command("complete", "Generate text from a trained GPT checkpoint");
+
+        var modelOption = new Option<string>("--model") { Description = "Checkpoint directory", DefaultValueFactory = _ => DefaultModelDir };
+        var promptOption = new Option<string>("--prompt") { Description = "Prompt to continue", Required = true };
+        var maxTokensOption = new Option<int>("--max-tokens") { Description = "Number of characters to generate", DefaultValueFactory = _ => 200 };
+        var temperatureOption = new Option<float>("--temperature") { Description = "Sampling temperature (0 = greedy/deterministic)", DefaultValueFactory = _ => 0.8f };
+        var seedOption = new Option<int>("--seed") { Description = "Random seed for sampling", DefaultValueFactory = _ => 1337 };
+
+        command.Add(modelOption);
+        command.Add(promptOption);
+        command.Add(maxTokensOption);
+        command.Add(temperatureOption);
+        command.Add(seedOption);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            try
+            {
+                var modelDir = parseResult.GetValue(modelOption)!;
+                var prompt = parseResult.GetValue(promptOption)!;
+                var maxTokens = parseResult.GetValue(maxTokensOption);
+                var temperature = parseResult.GetValue(temperatureOption);
+                var seed = parseResult.GetValue(seedOption);
+
+                var component = new GptCompleteComponent(new CheckpointService());
+                var result = await component.CompleteAsync(modelDir, prompt, maxTokens, temperature, seed);
+
+                AnsiConsole.WriteLine(result.Text);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                Environment.Exit(1);
+            }
+        });
+
+        return command;
+    }
+}

--- a/Pixelbadger.Toolkit/Components/GptCompleteComponent.cs
+++ b/Pixelbadger.Toolkit/Components/GptCompleteComponent.cs
@@ -1,0 +1,103 @@
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Components;
+
+public record GptCompleteResult(string Text);
+
+/// <summary>
+/// Loads a trained GPT checkpoint and autoregressively generates a continuation of a prompt.
+/// Temperature 0 yields deterministic greedy decoding.
+/// </summary>
+public class GptCompleteComponent
+{
+    private readonly ICheckpointService _checkpointService;
+
+    public GptCompleteComponent(ICheckpointService checkpointService)
+    {
+        _checkpointService = checkpointService;
+    }
+
+    public async Task<GptCompleteResult> CompleteAsync(
+        string modelDirectory,
+        string prompt,
+        int maxTokens,
+        float temperature,
+        int seed)
+    {
+        var checkpoint = await _checkpointService.LoadAsync(modelDirectory);
+        var tokenizer = CharTokenizer.FromVocabulary(checkpoint.Vocabulary);
+
+        var model = new GptModel(checkpoint.Config);
+        model.LoadWeights(checkpoint.Weights);
+
+        var ids = new List<int>();
+        if (!string.IsNullOrEmpty(prompt))
+            ids.AddRange(tokenizer.Encode(prompt));
+        if (ids.Count == 0)
+            ids.Add(0); // Seed with the first vocabulary symbol when no prompt is given.
+
+        var rng = new Random(seed);
+        int blockSize = checkpoint.Config.BlockSize;
+        int vocab = checkpoint.Config.VocabSize;
+
+        for (int i = 0; i < maxTokens; i++)
+        {
+            int contextLength = Math.Min(ids.Count, blockSize);
+            var context = new int[contextLength];
+            for (int j = 0; j < contextLength; j++)
+                context[j] = ids[ids.Count - contextLength + j];
+
+            var (logits, _) = model.Forward(new[] { context });
+
+            // Logits for the final time-step.
+            var lastLogits = new float[vocab];
+            Array.Copy(logits.Data, (contextLength - 1) * vocab, lastLogits, 0, vocab);
+
+            int next = temperature <= 0f
+                ? ArgMax(lastLogits)
+                : SampleWithTemperature(lastLogits, temperature, rng);
+
+            ids.Add(next);
+        }
+
+        return new GptCompleteResult(tokenizer.Decode(ids));
+    }
+
+    internal static int ArgMax(float[] values)
+    {
+        int best = 0;
+        for (int i = 1; i < values.Length; i++)
+            if (values[i] > values[best])
+                best = i;
+        return best;
+    }
+
+    internal static int SampleWithTemperature(float[] logits, float temperature, Random rng)
+    {
+        int n = logits.Length;
+        var probs = new float[n];
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < n; i++)
+        {
+            probs[i] = logits[i] / temperature;
+            if (probs[i] > max) max = probs[i];
+        }
+
+        float sum = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            probs[i] = MathF.Exp(probs[i] - max);
+            sum += probs[i];
+        }
+
+        float r = (float)rng.NextDouble() * sum;
+        float cumulative = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            cumulative += probs[i];
+            if (r <= cumulative)
+                return i;
+        }
+        return n - 1;
+    }
+}

--- a/Pixelbadger.Toolkit/Components/GptTrainComponent.cs
+++ b/Pixelbadger.Toolkit/Components/GptTrainComponent.cs
@@ -1,0 +1,95 @@
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Components;
+
+public record GptTrainResult(int Steps, float FinalLoss, string CheckpointPath, int ParameterCount, int VocabSize);
+
+public record GptTrainOptions(
+    int Steps = 2000,
+    int BatchSize = 16,
+    int BlockSize = 64,
+    int NEmbd = 128,
+    int NHead = 4,
+    int NLayer = 3,
+    float LearningRate = 3e-4f,
+    int Seed = 1337);
+
+/// <summary>
+/// Trains a tiny char-level GPT from a text corpus by gradient descent and writes a checkpoint.
+/// </summary>
+public class GptTrainComponent
+{
+    private readonly ICheckpointService _checkpointService;
+
+    public GptTrainComponent(ICheckpointService checkpointService)
+    {
+        _checkpointService = checkpointService;
+    }
+
+    public async Task<GptTrainResult> TrainAsync(
+        string corpus,
+        string outputDirectory,
+        GptTrainOptions options,
+        Action<int, float>? onProgress = null)
+    {
+        if (string.IsNullOrEmpty(corpus))
+            throw new ArgumentException("Training corpus is empty.", nameof(corpus));
+        if (options.NEmbd % options.NHead != 0)
+            throw new ArgumentException($"n-embd ({options.NEmbd}) must be divisible by n-head ({options.NHead}).");
+
+        var tokenizer = CharTokenizer.Build(corpus);
+        var data = tokenizer.Encode(corpus);
+
+        if (data.Length < options.BlockSize + 1)
+            throw new ArgumentException(
+                $"Corpus is too short ({data.Length} chars) for block size {options.BlockSize}; need at least {options.BlockSize + 1}.");
+
+        var config = new GptConfig(tokenizer.VocabSize, options.BlockSize, options.NEmbd, options.NHead, options.NLayer);
+        var model = new GptModel(config);
+        model.InitWeights(options.Seed);
+
+        var optimizer = new AdamW(model.Parameters(), options.LearningRate);
+        var rng = new Random(options.Seed);
+
+        float lastLoss = 0f;
+        for (int step = 1; step <= options.Steps; step++)
+        {
+            var (inputs, targets) = SampleBatch(data, options.BatchSize, options.BlockSize, rng);
+
+            model.ZeroGrad();
+            var (_, loss) = model.Forward(inputs, targets);
+            loss!.Backward();
+            optimizer.Step();
+
+            lastLoss = loss.Data[0];
+            onProgress?.Invoke(step, lastLoss);
+        }
+
+        await _checkpointService.SaveAsync(outputDirectory, config, tokenizer.Vocabulary, model.Parameters());
+
+        return new GptTrainResult(options.Steps, lastLoss, outputDirectory, model.ParameterCount(), tokenizer.VocabSize);
+    }
+
+    internal static (int[][] Inputs, int[][] Targets) SampleBatch(int[] data, int batchSize, int blockSize, Random rng)
+    {
+        var inputs = new int[batchSize][];
+        var targets = new int[batchSize][];
+        int maxStart = data.Length - blockSize - 1;
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            int start = rng.Next(maxStart + 1);
+            var inp = new int[blockSize];
+            var tgt = new int[blockSize];
+            for (int t = 0; t < blockSize; t++)
+            {
+                inp[t] = data[start + t];
+                tgt[t] = data[start + t + 1];
+            }
+            inputs[b] = inp;
+            targets[b] = tgt;
+        }
+
+        return (inputs, targets);
+    }
+}

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>6.1.0</Version>
+    <Version>6.2.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, LLM integration, and homomorphic encryption.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;llm;openai;crypto;homomorphic-encryption</PackageTags>
@@ -40,6 +40,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="Spectre.Console" Version="0.57.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.8" />
+    <PackageReference Include="System.Numerics.Tensors" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/Pixelbadger.Toolkit/Program.cs
+++ b/Pixelbadger.Toolkit/Program.cs
@@ -10,5 +10,6 @@ rootCommand.Add(WebCommand.Create());
 rootCommand.Add(LlmCommand.Create());
 rootCommand.Add(OAuthCommand.Create());
 rootCommand.Add(CryptoCommand.Create());
+rootCommand.Add(GptCommand.Create());
 
 return await rootCommand.Parse(args).InvokeAsync();

--- a/Pixelbadger.Toolkit/Services/AdamW.cs
+++ b/Pixelbadger.Toolkit/Services/AdamW.cs
@@ -1,0 +1,64 @@
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// AdamW optimizer (decoupled weight decay) over a fixed set of parameter tensors.
+/// </summary>
+public sealed class AdamW
+{
+    private readonly IReadOnlyList<Tensor> _parameters;
+    private readonly float _lr;
+    private readonly float _beta1;
+    private readonly float _beta2;
+    private readonly float _eps;
+    private readonly float _weightDecay;
+
+    private readonly float[][] _m;
+    private readonly float[][] _v;
+    private int _step;
+
+    public AdamW(
+        IReadOnlyList<Tensor> parameters,
+        float lr = 3e-4f,
+        float beta1 = 0.9f,
+        float beta2 = 0.95f,
+        float eps = 1e-8f,
+        float weightDecay = 0.1f)
+    {
+        _parameters = parameters;
+        _lr = lr;
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _eps = eps;
+        _weightDecay = weightDecay;
+
+        _m = parameters.Select(p => new float[p.Length]).ToArray();
+        _v = parameters.Select(p => new float[p.Length]).ToArray();
+    }
+
+    public void Step()
+    {
+        _step++;
+        float biasCorr1 = 1f - MathF.Pow(_beta1, _step);
+        float biasCorr2 = 1f - MathF.Pow(_beta2, _step);
+
+        for (int pi = 0; pi < _parameters.Count; pi++)
+        {
+            var p = _parameters[pi];
+            var m = _m[pi];
+            var v = _v[pi];
+
+            for (int i = 0; i < p.Length; i++)
+            {
+                float g = p.Grad[i];
+                m[i] = _beta1 * m[i] + (1f - _beta1) * g;
+                v[i] = _beta2 * v[i] + (1f - _beta2) * g * g;
+
+                float mHat = m[i] / biasCorr1;
+                float vHat = v[i] / biasCorr2;
+
+                // Decoupled weight decay followed by the Adam step.
+                p.Data[i] -= _lr * (_weightDecay * p.Data[i] + mHat / (MathF.Sqrt(vHat) + _eps));
+            }
+        }
+    }
+}

--- a/Pixelbadger.Toolkit/Services/CharTokenizer.cs
+++ b/Pixelbadger.Toolkit/Services/CharTokenizer.cs
@@ -1,0 +1,54 @@
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// Character-level tokenizer. The vocabulary is the sorted set of distinct characters in the
+/// training corpus, mirroring the approach used in Karpathy's char-level demos.
+/// </summary>
+public sealed class CharTokenizer
+{
+    private readonly Dictionary<char, int> _stoi;
+    private readonly char[] _itos;
+
+    public int VocabSize => _itos.Length;
+    public IReadOnlyList<char> Vocabulary => _itos;
+
+    private CharTokenizer(char[] itos)
+    {
+        _itos = itos;
+        _stoi = new Dictionary<char, int>(itos.Length);
+        for (int i = 0; i < itos.Length; i++)
+            _stoi[itos[i]] = i;
+    }
+
+    public static CharTokenizer Build(string corpus)
+    {
+        if (string.IsNullOrEmpty(corpus))
+            throw new ArgumentException("Cannot build a tokenizer from an empty corpus.", nameof(corpus));
+
+        var itos = corpus.Distinct().OrderBy(c => c).ToArray();
+        return new CharTokenizer(itos);
+    }
+
+    public static CharTokenizer FromVocabulary(IEnumerable<char> vocabulary)
+        => new(vocabulary.ToArray());
+
+    public int[] Encode(string text)
+    {
+        var ids = new int[text.Length];
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (!_stoi.TryGetValue(text[i], out var id))
+                throw new ArgumentException($"Character '{text[i]}' is not present in the model vocabulary.");
+            ids[i] = id;
+        }
+        return ids;
+    }
+
+    public string Decode(IReadOnlyList<int> ids)
+    {
+        var chars = new char[ids.Count];
+        for (int i = 0; i < ids.Count; i++)
+            chars[i] = _itos[ids[i]];
+        return new string(chars);
+    }
+}

--- a/Pixelbadger.Toolkit/Services/CheckpointService.cs
+++ b/Pixelbadger.Toolkit/Services/CheckpointService.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// Persists and restores a GPT checkpoint as a directory containing a JSON sidecar
+/// (model config + vocabulary) and a binary blob of the weight tensors.
+/// </summary>
+public sealed class CheckpointService : ICheckpointService
+{
+    internal const string ConfigFileName = "config.json";
+    internal const string WeightsFileName = "weights.bin";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private sealed record ConfigDto(
+        int VocabSize, int BlockSize, int NEmbd, int NHead, int NLayer, string Vocabulary);
+
+    public async Task SaveAsync(
+        string directory, GptConfig config, IReadOnlyList<char> vocabulary, IReadOnlyList<Tensor> parameters)
+    {
+        Directory.CreateDirectory(directory);
+
+        var dto = new ConfigDto(
+            config.VocabSize, config.BlockSize, config.NEmbd, config.NHead, config.NLayer,
+            new string(vocabulary.ToArray()));
+        var json = JsonSerializer.Serialize(dto, SerializerOptions);
+        await File.WriteAllTextAsync(Path.Combine(directory, ConfigFileName), json);
+
+        await using var stream = File.Create(Path.Combine(directory, WeightsFileName));
+        await using var writer = new BinaryWriter(stream);
+        writer.Write(parameters.Count);
+        foreach (var p in parameters)
+        {
+            writer.Write(p.Length);
+            for (int i = 0; i < p.Length; i++)
+                writer.Write(p.Data[i]);
+        }
+    }
+
+    public async Task<GptCheckpoint> LoadAsync(string directory)
+    {
+        var configPath = Path.Combine(directory, ConfigFileName);
+        var weightsPath = Path.Combine(directory, WeightsFileName);
+
+        if (!File.Exists(configPath) || !File.Exists(weightsPath))
+            throw new FileNotFoundException(
+                $"No GPT checkpoint found in '{directory}'. Run 'gpt train' first.");
+
+        var json = await File.ReadAllTextAsync(configPath);
+        var dto = JsonSerializer.Deserialize<ConfigDto>(json)
+            ?? throw new InvalidDataException("Failed to deserialize GPT config.");
+
+        var config = new GptConfig(dto.VocabSize, dto.BlockSize, dto.NEmbd, dto.NHead, dto.NLayer);
+
+        await using var stream = File.OpenRead(weightsPath);
+        using var reader = new BinaryReader(stream);
+        int count = reader.ReadInt32();
+        var weights = new float[count][];
+        for (int p = 0; p < count; p++)
+        {
+            int length = reader.ReadInt32();
+            var data = new float[length];
+            for (int i = 0; i < length; i++)
+                data[i] = reader.ReadSingle();
+            weights[p] = data;
+        }
+
+        return new GptCheckpoint(config, dto.Vocabulary.ToCharArray(), weights);
+    }
+}

--- a/Pixelbadger.Toolkit/Services/GptModel.cs
+++ b/Pixelbadger.Toolkit/Services/GptModel.cs
@@ -1,0 +1,229 @@
+namespace Pixelbadger.Toolkit.Services;
+
+public record GptConfig(int VocabSize, int BlockSize, int NEmbd, int NHead, int NLayer)
+{
+    public int HeadDim => NEmbd / NHead;
+}
+
+/// <summary>
+/// A tiny char-level GPT (decoder-only transformer) built entirely from the hand-rolled
+/// <see cref="Tensor"/> autograd engine. Architecture follows nanoGPT: token + positional
+/// embeddings, pre-LayerNorm transformer blocks (causal multi-head self-attention + MLP),
+/// a final LayerNorm, and a weight-tied linear head.
+/// </summary>
+public sealed class GptModel
+{
+    private sealed class Block
+    {
+        public required Tensor Ln1Gamma, Ln1Beta;
+        public required Tensor Wq, Bq, Wk, Bk, Wv, Bv, Wo, Bo;
+        public required Tensor Ln2Gamma, Ln2Beta;
+        public required Tensor Wfc, Bfc, Wproj, Bproj;
+    }
+
+    public GptConfig Config { get; }
+
+    private readonly Tensor _wte;   // token embedding (V, C), also the tied output head
+    private readonly Tensor _wpe;   // positional embedding (block, C)
+    private readonly Block[] _blocks;
+    private readonly Tensor _lnfGamma, _lnfBeta;
+    private readonly List<Tensor> _parameters = new();
+
+    public GptModel(GptConfig config)
+    {
+        Config = config;
+        int c = config.NEmbd;
+
+        _wte = Param(config.VocabSize, c);
+        _wpe = Param(config.BlockSize, c);
+
+        _blocks = new Block[config.NLayer];
+        for (int i = 0; i < config.NLayer; i++)
+        {
+            _blocks[i] = new Block
+            {
+                Ln1Gamma = Param(1, c), Ln1Beta = Param(1, c),
+                Wq = Param(c, c), Bq = Param(1, c),
+                Wk = Param(c, c), Bk = Param(1, c),
+                Wv = Param(c, c), Bv = Param(1, c),
+                Wo = Param(c, c), Bo = Param(1, c),
+                Ln2Gamma = Param(1, c), Ln2Beta = Param(1, c),
+                Wfc = Param(c, 4 * c), Bfc = Param(1, 4 * c),
+                Wproj = Param(4 * c, c), Bproj = Param(1, c)
+            };
+        }
+
+        _lnfGamma = Param(1, c);
+        _lnfBeta = Param(1, c);
+    }
+
+    private Tensor Param(int rows, int cols)
+    {
+        var t = new Tensor(rows, cols, requiresGrad: true);
+        _parameters.Add(t);
+        return t;
+    }
+
+    /// <summary>Parameters in a fixed construction order (used for checkpointing and the optimizer).</summary>
+    public IReadOnlyList<Tensor> Parameters() => _parameters;
+
+    public int ParameterCount() => _parameters.Sum(p => p.Length);
+
+    public void ZeroGrad()
+    {
+        foreach (var p in _parameters)
+            p.ZeroGrad();
+    }
+
+    /// <summary>Copies persisted weights into the parameter tensors (must match construction order and shapes).</summary>
+    public void LoadWeights(IReadOnlyList<float[]> weights)
+    {
+        if (weights.Count != _parameters.Count)
+            throw new ArgumentException(
+                $"Checkpoint has {weights.Count} weight tensors but the model expects {_parameters.Count}.");
+
+        for (int i = 0; i < _parameters.Count; i++)
+        {
+            if (weights[i].Length != _parameters[i].Length)
+                throw new ArgumentException(
+                    $"Weight tensor {i} length {weights[i].Length} does not match expected {_parameters[i].Length}.");
+            Array.Copy(weights[i], _parameters[i].Data, weights[i].Length);
+        }
+    }
+
+    /// <summary>Initializes weights from a seeded RNG: N(0, 0.02) for matrices, 0 for biases, LayerNorm gamma=1.</summary>
+    public void InitWeights(int seed)
+    {
+        var rng = new Random(seed);
+
+        RandomNormal(rng, _wte, 0.02f);
+        RandomNormal(rng, _wpe, 0.02f);
+
+        foreach (var b in _blocks)
+        {
+            Ones(b.Ln1Gamma); Zeros(b.Ln1Beta);
+            RandomNormal(rng, b.Wq, 0.02f); Zeros(b.Bq);
+            RandomNormal(rng, b.Wk, 0.02f); Zeros(b.Bk);
+            RandomNormal(rng, b.Wv, 0.02f); Zeros(b.Bv);
+            RandomNormal(rng, b.Wo, 0.02f); Zeros(b.Bo);
+            Ones(b.Ln2Gamma); Zeros(b.Ln2Beta);
+            RandomNormal(rng, b.Wfc, 0.02f); Zeros(b.Bfc);
+            RandomNormal(rng, b.Wproj, 0.02f); Zeros(b.Bproj);
+        }
+
+        Ones(_lnfGamma);
+        Zeros(_lnfBeta);
+    }
+
+    private static void RandomNormal(Random rng, Tensor t, float std)
+    {
+        for (int i = 0; i < t.Length; i++)
+        {
+            // Box-Muller transform.
+            double u1 = 1.0 - rng.NextDouble();
+            double u2 = 1.0 - rng.NextDouble();
+            double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+            t.Data[i] = (float)(z * std);
+        }
+    }
+
+    private static void Ones(Tensor t) => Array.Fill(t.Data, 1f);
+    private static void Zeros(Tensor t) => Array.Clear(t.Data, 0, t.Length);
+
+    /// <summary>
+    /// Forward pass over a batch of equal-length token sequences. Returns the logits (B*T, vocab)
+    /// and, when targets are supplied, the mean cross-entropy loss as a 1x1 tensor.
+    /// </summary>
+    public (Tensor Logits, Tensor? Loss) Forward(int[][] batch, int[][]? targets = null)
+    {
+        int b = batch.Length;
+        int t = batch[0].Length;
+        if (t > Config.BlockSize)
+            throw new ArgumentException($"Sequence length {t} exceeds block size {Config.BlockSize}.");
+
+        int r = b * t;
+        var tokenIds = new int[r];
+        var posIds = new int[r];
+        for (int bi = 0; bi < b; bi++)
+            for (int ti = 0; ti < t; ti++)
+            {
+                tokenIds[bi * t + ti] = batch[bi][ti];
+                posIds[bi * t + ti] = ti;
+            }
+
+        var x = Tensor.Add(Tensor.Gather(_wte, tokenIds), Tensor.Gather(_wpe, posIds));
+
+        foreach (var block in _blocks)
+            x = ForwardBlock(x, block, b, t);
+
+        x = Tensor.LayerNorm(x, _lnfGamma, _lnfBeta);
+
+        // Weight-tied head: logits = x · Wteᵀ.
+        var logits = Tensor.MatMul(x, Tensor.Transpose(_wte));
+
+        if (targets is null)
+            return (logits, null);
+
+        var targetFlat = new int[r];
+        for (int bi = 0; bi < b; bi++)
+            for (int ti = 0; ti < t; ti++)
+                targetFlat[bi * t + ti] = targets[bi][ti];
+
+        var loss = Tensor.CrossEntropy(logits, targetFlat);
+        return (logits, loss);
+    }
+
+    private Tensor ForwardBlock(Tensor x, Block block, int b, int t)
+    {
+        var a = Tensor.LayerNorm(x, block.Ln1Gamma, block.Ln1Beta);
+        x = Tensor.Add(x, Attention(a, block, b, t));
+
+        var m = Tensor.LayerNorm(x, block.Ln2Gamma, block.Ln2Beta);
+        x = Tensor.Add(x, Mlp(m, block));
+        return x;
+    }
+
+    private Tensor Attention(Tensor a, Block block, int b, int t)
+    {
+        int hd = Config.HeadDim;
+        int h = Config.NHead;
+        float scale = 1f / MathF.Sqrt(hd);
+
+        var q = Tensor.AddBias(Tensor.MatMul(a, block.Wq), block.Bq);
+        var k = Tensor.AddBias(Tensor.MatMul(a, block.Wk), block.Bk);
+        var v = Tensor.AddBias(Tensor.MatMul(a, block.Wv), block.Bv);
+
+        var seqOutputs = new List<Tensor>(b);
+        for (int bi = 0; bi < b; bi++)
+        {
+            var qSeq = Tensor.SliceRows(q, bi * t, t);
+            var kSeq = Tensor.SliceRows(k, bi * t, t);
+            var vSeq = Tensor.SliceRows(v, bi * t, t);
+
+            var headOutputs = new List<Tensor>(h);
+            for (int hi = 0; hi < h; hi++)
+            {
+                var qh = Tensor.SliceCols(qSeq, hi * hd, hd);
+                var kh = Tensor.SliceCols(kSeq, hi * hd, hd);
+                var vh = Tensor.SliceCols(vSeq, hi * hd, hd);
+
+                var scores = Tensor.Scale(Tensor.MatMul(qh, Tensor.Transpose(kh)), scale);
+                scores = Tensor.CausalMask(scores);
+                var att = Tensor.SoftmaxRows(scores);
+                headOutputs.Add(Tensor.MatMul(att, vh));
+            }
+
+            seqOutputs.Add(Tensor.ConcatCols(headOutputs));
+        }
+
+        var attnConcat = Tensor.ConcatRows(seqOutputs);
+        return Tensor.AddBias(Tensor.MatMul(attnConcat, block.Wo), block.Bo);
+    }
+
+    private static Tensor Mlp(Tensor x, Block block)
+    {
+        var h = Tensor.AddBias(Tensor.MatMul(x, block.Wfc), block.Bfc);
+        h = Tensor.Gelu(h);
+        return Tensor.AddBias(Tensor.MatMul(h, block.Wproj), block.Bproj);
+    }
+}

--- a/Pixelbadger.Toolkit/Services/ICheckpointService.cs
+++ b/Pixelbadger.Toolkit/Services/ICheckpointService.cs
@@ -1,0 +1,9 @@
+namespace Pixelbadger.Toolkit.Services;
+
+public record GptCheckpoint(GptConfig Config, char[] Vocabulary, float[][] Weights);
+
+public interface ICheckpointService
+{
+    Task SaveAsync(string directory, GptConfig config, IReadOnlyList<char> vocabulary, IReadOnlyList<Tensor> parameters);
+    Task<GptCheckpoint> LoadAsync(string directory);
+}

--- a/Pixelbadger.Toolkit/Services/Tensor.cs
+++ b/Pixelbadger.Toolkit/Services/Tensor.cs
@@ -1,0 +1,513 @@
+using System.Numerics.Tensors;
+
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// A minimal reverse-mode automatic differentiation engine over 2D float matrices,
+/// hand-rolled from scratch (no TorchSharp / native ML libraries) in the spirit of
+/// Karpathy's micrograd/nanoGPT. Hot kernels are accelerated with
+/// <see cref="System.Numerics.Tensors.TensorPrimitives"/> (SIMD) and, for matrix
+/// multiplication, <see cref="System.Threading.Tasks.Parallel"/> across independent
+/// output rows. Reductions inside a single dot-product are kept sequential so results
+/// are independent of thread count and therefore reproducible.
+/// </summary>
+public sealed class Tensor
+{
+    public int Rows { get; }
+    public int Cols { get; }
+    public float[] Data { get; }
+    public float[] Grad { get; }
+    public bool RequiresGrad { get; set; }
+
+    internal readonly List<Tensor> Parents = new();
+    internal Action? BackwardFn;
+
+    public int Length => Data.Length;
+
+    public Tensor(int rows, int cols, bool requiresGrad = false)
+    {
+        Rows = rows;
+        Cols = cols;
+        Data = new float[rows * cols];
+        Grad = new float[rows * cols];
+        RequiresGrad = requiresGrad;
+    }
+
+    public static Tensor FromData(int rows, int cols, float[] data, bool requiresGrad = false)
+    {
+        if (data.Length != rows * cols)
+            throw new ArgumentException($"Data length {data.Length} does not match shape {rows}x{cols}.");
+        var t = new Tensor(rows, cols, requiresGrad);
+        Array.Copy(data, t.Data, data.Length);
+        return t;
+    }
+
+    public void ZeroGrad() => Array.Clear(Grad, 0, Grad.Length);
+
+    /// <summary>
+    /// Runs reverse-mode autodiff from this tensor (treated as the loss root). Performs a
+    /// topological sort of the graph and accumulates gradients into every node's <see cref="Grad"/>.
+    /// </summary>
+    public void Backward()
+    {
+        var topo = new List<Tensor>();
+        var visited = new HashSet<Tensor>();
+        BuildTopo(this, visited, topo);
+
+        // Seed the root gradient with ones (loss is typically a 1x1 scalar).
+        Array.Fill(Grad, 1f);
+
+        for (int i = topo.Count - 1; i >= 0; i--)
+            topo[i].BackwardFn?.Invoke();
+    }
+
+    private static void BuildTopo(Tensor node, HashSet<Tensor> visited, List<Tensor> topo)
+    {
+        if (!visited.Add(node))
+            return;
+        foreach (var parent in node.Parents)
+            BuildTopo(parent, visited, topo);
+        topo.Add(node);
+    }
+
+    private static void AccumulateInPlace(float[] dest, ReadOnlySpan<float> src)
+        => TensorPrimitives.Add(dest, src, dest);
+
+    // ---- Helpers -------------------------------------------------------------------
+
+    internal static float[] Transpose(float[] data, int rows, int cols)
+    {
+        var result = new float[rows * cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[j * rows + i] = data[i * cols + j];
+        return result;
+    }
+
+    // ---- Core ops ------------------------------------------------------------------
+
+    /// <summary>Matrix multiply: A(m,k) · B(k,n) = (m,n). SIMD dot products, parallel over rows.</summary>
+    public static Tensor MatMul(Tensor a, Tensor b)
+    {
+        if (a.Cols != b.Rows)
+            throw new ArgumentException($"MatMul shape mismatch: {a.Rows}x{a.Cols} · {b.Rows}x{b.Cols}.");
+
+        int m = a.Rows, k = a.Cols, n = b.Cols;
+        var outp = new Tensor(m, n);
+
+        // Pre-transpose B so each column is a contiguous span for TensorPrimitives.Dot.
+        var bt = Transpose(b.Data, k, n); // (n, k)
+
+        Parallel.For(0, m, i =>
+        {
+            var aRow = new ReadOnlySpan<float>(a.Data, i * k, k);
+            for (int j = 0; j < n; j++)
+            {
+                var btRow = new ReadOnlySpan<float>(bt, j * k, k);
+                outp.Data[i * n + j] = TensorPrimitives.Dot(aRow, btRow);
+            }
+        });
+
+        outp.Parents.Add(a);
+        outp.Parents.Add(b);
+        outp.BackwardFn = () =>
+        {
+            // dA[i,l] = sum_j dY[i,j] * B[l,j] = Dot(dY_row_i, B_row_l)
+            Parallel.For(0, m, i =>
+            {
+                var dyRow = new ReadOnlySpan<float>(outp.Grad, i * n, n);
+                for (int l = 0; l < k; l++)
+                {
+                    var bRow = new ReadOnlySpan<float>(b.Data, l * n, n);
+                    a.Grad[i * k + l] += TensorPrimitives.Dot(dyRow, bRow);
+                }
+            });
+
+            // dB[l,j] = sum_i A[i,l] * dY[i,j] = Dot(At_row_l, dYt_row_j)
+            var at = Transpose(a.Data, m, k);       // (k, m)
+            var dyt = Transpose(outp.Grad, m, n);   // (n, m)
+            Parallel.For(0, k, l =>
+            {
+                var atRow = new ReadOnlySpan<float>(at, l * m, m);
+                for (int j = 0; j < n; j++)
+                {
+                    var dytRow = new ReadOnlySpan<float>(dyt, j * m, m);
+                    b.Grad[l * n + j] += TensorPrimitives.Dot(atRow, dytRow);
+                }
+            });
+        };
+        return outp;
+    }
+
+    /// <summary>Transpose with autograd: X(r,c) -> (c,r).</summary>
+    public static Tensor Transpose(Tensor x)
+    {
+        var outp = new Tensor(x.Cols, x.Rows);
+        var t = Transpose(x.Data, x.Rows, x.Cols);
+        Array.Copy(t, outp.Data, t.Length);
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < x.Rows; i++)
+                for (int j = 0; j < x.Cols; j++)
+                    x.Grad[i * x.Cols + j] += outp.Grad[j * x.Rows + i];
+        };
+        return outp;
+    }
+
+    /// <summary>Adds a per-column bias (broadcast over rows): X(r,c) + b(1,c).</summary>
+    public static Tensor AddBias(Tensor x, Tensor bias)
+    {
+        if (bias.Length != x.Cols)
+            throw new ArgumentException("Bias length must equal number of columns.");
+
+        var outp = new Tensor(x.Rows, x.Cols);
+        for (int i = 0; i < x.Rows; i++)
+        {
+            var xRow = new ReadOnlySpan<float>(x.Data, i * x.Cols, x.Cols);
+            var oRow = new Span<float>(outp.Data, i * x.Cols, x.Cols);
+            TensorPrimitives.Add(xRow, bias.Data, oRow);
+        }
+
+        outp.Parents.Add(x);
+        outp.Parents.Add(bias);
+        outp.BackwardFn = () =>
+        {
+            AccumulateInPlace(x.Grad, outp.Grad);
+            for (int i = 0; i < x.Rows; i++)
+                for (int j = 0; j < x.Cols; j++)
+                    bias.Grad[j] += outp.Grad[i * x.Cols + j];
+        };
+        return outp;
+    }
+
+    /// <summary>Elementwise add of two equally-shaped tensors (used for residual connections).</summary>
+    public static Tensor Add(Tensor a, Tensor b)
+    {
+        if (a.Rows != b.Rows || a.Cols != b.Cols)
+            throw new ArgumentException("Add shape mismatch.");
+
+        var outp = new Tensor(a.Rows, a.Cols);
+        TensorPrimitives.Add(a.Data, b.Data, outp.Data);
+
+        outp.Parents.Add(a);
+        outp.Parents.Add(b);
+        outp.BackwardFn = () =>
+        {
+            AccumulateInPlace(a.Grad, outp.Grad);
+            AccumulateInPlace(b.Grad, outp.Grad);
+        };
+        return outp;
+    }
+
+    /// <summary>Multiply every element by a scalar constant.</summary>
+    public static Tensor Scale(Tensor x, float s)
+    {
+        var outp = new Tensor(x.Rows, x.Cols);
+        TensorPrimitives.Multiply(x.Data, s, outp.Data);
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < x.Length; i++)
+                x.Grad[i] += outp.Grad[i] * s;
+        };
+        return outp;
+    }
+
+    /// <summary>Row-wise softmax with max-subtraction for numerical stability.</summary>
+    public static Tensor SoftmaxRows(Tensor x)
+    {
+        int r = x.Rows, c = x.Cols;
+        var outp = new Tensor(r, c);
+
+        for (int i = 0; i < r; i++)
+        {
+            var row = new ReadOnlySpan<float>(x.Data, i * c, c);
+            var oRow = new Span<float>(outp.Data, i * c, c);
+            float max = TensorPrimitives.Max(row);
+            TensorPrimitives.Subtract(row, max, oRow);
+            TensorPrimitives.Exp(oRow, oRow);
+            float sum = TensorPrimitives.Sum(oRow);
+            TensorPrimitives.Divide(oRow, sum, oRow);
+        }
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < r; i++)
+            {
+                var y = new ReadOnlySpan<float>(outp.Data, i * c, c);
+                var dy = new ReadOnlySpan<float>(outp.Grad, i * c, c);
+                float dot = TensorPrimitives.Dot(dy, y);
+                for (int j = 0; j < c; j++)
+                    x.Grad[i * c + j] += y[j] * (dy[j] - dot);
+            }
+        };
+        return outp;
+    }
+
+    /// <summary>Row-wise layer normalization with learnable gamma/beta.</summary>
+    public static Tensor LayerNorm(Tensor x, Tensor gamma, Tensor beta, float eps = 1e-5f)
+    {
+        int r = x.Rows, c = x.Cols;
+        var outp = new Tensor(r, c);
+        var xhat = new float[r * c];
+        var invStd = new float[r];
+
+        for (int i = 0; i < r; i++)
+        {
+            var row = new ReadOnlySpan<float>(x.Data, i * c, c);
+            float mean = TensorPrimitives.Sum(row) / c;
+            float var = 0f;
+            for (int j = 0; j < c; j++)
+            {
+                float d = row[j] - mean;
+                var += d * d;
+            }
+            var /= c;
+            float istd = 1f / MathF.Sqrt(var + eps);
+            invStd[i] = istd;
+            for (int j = 0; j < c; j++)
+            {
+                float xh = (row[j] - mean) * istd;
+                xhat[i * c + j] = xh;
+                outp.Data[i * c + j] = gamma.Data[j] * xh + beta.Data[j];
+            }
+        }
+
+        outp.Parents.Add(x);
+        outp.Parents.Add(gamma);
+        outp.Parents.Add(beta);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < r; i++)
+            {
+                // dxhat_j = dy_j * gamma_j
+                float sumDxhat = 0f, sumDxhatXhat = 0f;
+                for (int j = 0; j < c; j++)
+                {
+                    float dy = outp.Grad[i * c + j];
+                    float dxhat = dy * gamma.Data[j];
+                    sumDxhat += dxhat;
+                    sumDxhatXhat += dxhat * xhat[i * c + j];
+                    gamma.Grad[j] += dy * xhat[i * c + j];
+                    beta.Grad[j] += dy;
+                }
+                float istd = invStd[i];
+                for (int j = 0; j < c; j++)
+                {
+                    float dxhat = outp.Grad[i * c + j] * gamma.Data[j];
+                    x.Grad[i * c + j] += (istd / c) * (c * dxhat - sumDxhat - xhat[i * c + j] * sumDxhatXhat);
+                }
+            }
+        };
+        return outp;
+    }
+
+    private const float GeluC = 0.7978845608028654f; // sqrt(2/pi)
+    private const float GeluA = 0.044715f;
+
+    /// <summary>GELU activation (tanh approximation), elementwise.</summary>
+    public static Tensor Gelu(Tensor x)
+    {
+        var outp = new Tensor(x.Rows, x.Cols);
+        for (int i = 0; i < x.Length; i++)
+        {
+            float v = x.Data[i];
+            float inner = GeluC * (v + GeluA * v * v * v);
+            float t = MathF.Tanh(inner);
+            outp.Data[i] = 0.5f * v * (1f + t);
+        }
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < x.Length; i++)
+            {
+                float v = x.Data[i];
+                float inner = GeluC * (v + GeluA * v * v * v);
+                float t = MathF.Tanh(inner);
+                float dInner = GeluC * (1f + 3f * GeluA * v * v);
+                float dgelu = 0.5f * (1f + t) + 0.5f * v * (1f - t * t) * dInner;
+                x.Grad[i] += outp.Grad[i] * dgelu;
+            }
+        };
+        return outp;
+    }
+
+    /// <summary>Adds a causal mask to a (T,T) score matrix: positions j &gt; i become -1e9.</summary>
+    public static Tensor CausalMask(Tensor scores)
+    {
+        if (scores.Rows != scores.Cols)
+            throw new ArgumentException("Causal mask requires a square (T,T) score matrix.");
+
+        int t = scores.Rows;
+        var outp = new Tensor(t, t);
+        for (int i = 0; i < t; i++)
+            for (int j = 0; j < t; j++)
+                outp.Data[i * t + j] = j <= i ? scores.Data[i * t + j] : -1e9f;
+
+        outp.Parents.Add(scores);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < t; i++)
+                for (int j = 0; j <= i; j++)
+                    scores.Grad[i * t + j] += outp.Grad[i * t + j];
+        };
+        return outp;
+    }
+
+    /// <summary>Extract a contiguous block of rows.</summary>
+    public static Tensor SliceRows(Tensor x, int startRow, int count)
+    {
+        var outp = new Tensor(count, x.Cols);
+        Array.Copy(x.Data, startRow * x.Cols, outp.Data, 0, count * x.Cols);
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < count * x.Cols; i++)
+                x.Grad[startRow * x.Cols + i] += outp.Grad[i];
+        };
+        return outp;
+    }
+
+    /// <summary>Extract a contiguous block of columns (e.g. a single attention head).</summary>
+    public static Tensor SliceCols(Tensor x, int startCol, int count)
+    {
+        var outp = new Tensor(x.Rows, count);
+        for (int i = 0; i < x.Rows; i++)
+            for (int j = 0; j < count; j++)
+                outp.Data[i * count + j] = x.Data[i * x.Cols + startCol + j];
+
+        outp.Parents.Add(x);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < x.Rows; i++)
+                for (int j = 0; j < count; j++)
+                    x.Grad[i * x.Cols + startCol + j] += outp.Grad[i * count + j];
+        };
+        return outp;
+    }
+
+    /// <summary>Concatenate tensors along columns (all must share row count).</summary>
+    public static Tensor ConcatCols(IReadOnlyList<Tensor> parts)
+    {
+        int rows = parts[0].Rows;
+        int totalCols = parts.Sum(p => p.Cols);
+        var outp = new Tensor(rows, totalCols);
+
+        int colOffset = 0;
+        foreach (var p in parts)
+        {
+            for (int i = 0; i < rows; i++)
+                for (int j = 0; j < p.Cols; j++)
+                    outp.Data[i * totalCols + colOffset + j] = p.Data[i * p.Cols + j];
+            colOffset += p.Cols;
+        }
+
+        foreach (var p in parts)
+            outp.Parents.Add(p);
+
+        outp.BackwardFn = () =>
+        {
+            int off = 0;
+            foreach (var p in parts)
+            {
+                for (int i = 0; i < rows; i++)
+                    for (int j = 0; j < p.Cols; j++)
+                        p.Grad[i * p.Cols + j] += outp.Grad[i * totalCols + off + j];
+                off += p.Cols;
+            }
+        };
+        return outp;
+    }
+
+    /// <summary>Concatenate tensors along rows (all must share column count).</summary>
+    public static Tensor ConcatRows(IReadOnlyList<Tensor> parts)
+    {
+        int cols = parts[0].Cols;
+        int totalRows = parts.Sum(p => p.Rows);
+        var outp = new Tensor(totalRows, cols);
+
+        int rowOffset = 0;
+        foreach (var p in parts)
+        {
+            Array.Copy(p.Data, 0, outp.Data, rowOffset * cols, p.Rows * cols);
+            rowOffset += p.Rows;
+        }
+
+        foreach (var p in parts)
+            outp.Parents.Add(p);
+
+        outp.BackwardFn = () =>
+        {
+            int off = 0;
+            foreach (var p in parts)
+            {
+                for (int i = 0; i < p.Rows * cols; i++)
+                    p.Grad[i] += outp.Grad[off * cols + i];
+                off += p.Rows;
+            }
+        };
+        return outp;
+    }
+
+    /// <summary>Gather rows from a (V,C) table by integer ids, producing (ids.Length, C).</summary>
+    public static Tensor Gather(Tensor table, int[] ids)
+    {
+        int c = table.Cols;
+        var outp = new Tensor(ids.Length, c);
+        for (int i = 0; i < ids.Length; i++)
+            Array.Copy(table.Data, ids[i] * c, outp.Data, i * c, c);
+
+        outp.Parents.Add(table);
+        outp.BackwardFn = () =>
+        {
+            for (int i = 0; i < ids.Length; i++)
+                for (int j = 0; j < c; j++)
+                    table.Grad[ids[i] * c + j] += outp.Grad[i * c + j];
+        };
+        return outp;
+    }
+
+    /// <summary>
+    /// Fused softmax cross-entropy over logits (N,V) against integer targets, returning the
+    /// mean negative log-likelihood as a 1x1 scalar tensor.
+    /// </summary>
+    public static Tensor CrossEntropy(Tensor logits, int[] targets)
+    {
+        int n = logits.Rows, v = logits.Cols;
+        var outp = new Tensor(1, 1);
+        var probs = new float[n * v];
+
+        float lossSum = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            var row = new ReadOnlySpan<float>(logits.Data, i * v, v);
+            var pRow = new Span<float>(probs, i * v, v);
+            float max = TensorPrimitives.Max(row);
+            TensorPrimitives.Subtract(row, max, pRow);
+            TensorPrimitives.Exp(pRow, pRow);
+            float sum = TensorPrimitives.Sum(pRow);
+            TensorPrimitives.Divide(pRow, sum, pRow);
+            lossSum += -MathF.Log(Math.Max(pRow[targets[i]], 1e-12f));
+        }
+        outp.Data[0] = lossSum / n;
+
+        outp.Parents.Add(logits);
+        outp.BackwardFn = () =>
+        {
+            float g = outp.Grad[0] / n;
+            for (int i = 0; i < n; i++)
+            {
+                for (int j = 0; j < v; j++)
+                    logits.Grad[i * v + j] += g * probs[i * v + j];
+                logits.Grad[i * v + targets[i]] -= g;
+            }
+        };
+        return outp;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -348,6 +348,52 @@ pbtk crypto substring --in-file msg.estr --start 6 --length 5 --out-file sub.est
 
 ---
 
+### gpt
+
+A tiny char-level GPT (decoder-only transformer) implemented entirely from scratch in pure C# — a hand-rolled tensor library with reverse-mode autograd, manual forward and backward passes, and an AdamW optimizer. Inspired by Karpathy's nanoGPT/microGPT. Hot kernels are accelerated with SIMD via `System.Numerics.Tensors` (`TensorPrimitives`) and `Parallel.For` across independent matmul rows; reductions are kept sequential so results are reproducible regardless of thread count.
+
+A checkpoint is a directory containing `config.json` (model config + vocabulary) and `weights.bin` (raw parameter floats).
+
+#### train
+
+Builds a character vocabulary from the corpus, trains the model by gradient descent, and writes a checkpoint.
+
+```
+--source <path>       Path to a training corpus file, or literal text (required)
+--out <dir>           Checkpoint output directory (default: ./.gpt)
+--steps <int>         Number of training steps (default: 2000)
+--batch-size <int>    Sequences per training step (default: 16)
+--block-size <int>    Context length in characters (default: 64)
+--n-embd <int>        Embedding dimension (default: 128)
+--n-head <int>        Number of attention heads (default: 4)
+--n-layer <int>       Number of transformer blocks (default: 3)
+--lr <float>          Learning rate (default: 0.0003)
+--seed <int>          Random seed for reproducible runs (default: 1337)
+```
+```bash
+pbtk gpt train --source corpus.txt --out ./.gpt --steps 2000
+```
+
+> `--n-embd` must be divisible by `--n-head`, and the corpus must be longer than `--block-size`.
+
+#### complete
+
+Loads a checkpoint and autoregressively generates a continuation of the prompt.
+
+```
+--model <dir>          Checkpoint directory (default: ./.gpt)
+--prompt <text>        Prompt to continue (required)
+--max-tokens <int>     Number of characters to generate (default: 200)
+--temperature <float>  Sampling temperature; 0 = greedy/deterministic (default: 0.8)
+--seed <int>           Random seed for sampling (default: 1337)
+```
+```bash
+pbtk gpt complete --model ./.gpt --prompt "ROMEO:" --max-tokens 200
+pbtk gpt complete --model ./.gpt --prompt "The" --temperature 0
+```
+
+---
+
 ## Requirements
 
 - .NET 9.0


### PR DESCRIPTION
## Summary

Adds a new `gpt` topic with `train` and `complete` actions — a tiny decoder-only transformer (char-level GPT) implemented **entirely from scratch in pure C#**. Inspired by Karpathy's nanoGPT/microGPT.

- Hand-rolled tensor library with **reverse-mode autograd** (topological sort + gradient-accumulating closures), manual forward and backward passes
- Pre-LN transformer blocks: token + positional embeddings → causal multi-head self-attention + MLP → final LayerNorm → weight-tied linear head
- **AdamW** optimizer with decoupled weight decay; char-level tokenizer; binary checkpoint format (`config.json` + `weights.bin`)
- **Hardware optimization at the from-scratch level**: SIMD via `System.Numerics.Tensors` (`TensorPrimitives`) in hot kernels + `Parallel.For` across independent matmul rows. Reductions are kept sequential so floating-point results are reproducible regardless of thread count.

```bash
pbtk gpt train --source corpus.txt --out ./.gpt --steps 2000
pbtk gpt complete --model ./.gpt --prompt "ROMEO:" --max-tokens 200
```

## Test plan
- [x] Tests pass: `dotnet test` — 463 passed (all new GPT tests green, including 16 finite-difference gradient checks, overfit training convergence, greedy-determinism, checkpoint round-trip, and in-process command integration)
- [x] Version bumped in csproj (6.1.0 → 6.2.0, minor — new feature)
- [x] README and CLAUDE.md updated with the `gpt` topic

## Note
4 pre-existing `StringsCommandIntegrationTests` `report` tests fail in this environment (exit 1 under `dotnet run -c Release --no-build`). They are unrelated to this change — they exercise the untouched `strings report` command and are environmental (the sibling `flesch-reading-ease` integration tests pass through the same harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)