### PR TITLE
Add --loss-graph to gpt train with per-step loss and corpus coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ The project is .NET 9, and uses Microsoft's System.CommandLine library for build
   - `pbtk gpt train --source corpus.txt --out ./.gpt --tokenizer bpe --vocab-size 1024 --block-size 128`
   - `pbtk gpt train --source corpus.txt --out ./.gpt --tokenizer char`
   - `pbtk gpt train --source corpus.txt --out ./.gpt --steps 1000 --resume`
+  - `pbtk gpt train --source corpus.txt --out ./.gpt --loss-graph ./loss.html`
   - `pbtk gpt complete --model ./.gpt --prompt "ROMEO:" --max-tokens 200`
 
 ### Testing Requirements

--- a/Pixelbadger.Toolkit.Tests/CheckpointServiceTests.cs
+++ b/Pixelbadger.Toolkit.Tests/CheckpointServiceTests.cs
@@ -116,4 +116,69 @@ public class CheckpointServiceTests : IDisposable
 
         loaded.Should().BeNull();
     }
+
+    [Fact]
+    public async Task SaveThenLoadTrainingHistory_ShouldRoundTripSeriesBoundariesAndVisitedSets()
+    {
+        // Deliberately not a multiple of 8, to exercise the partial trailing byte of the packed bitmaps.
+        var positionSeen = new bool[13];
+        foreach (var i in new[] { 0, 3, 7, 8, 12 })
+            positionSeen[i] = true;
+        var vocabSeen = new[] { true, false, false, true };
+        var history = new TrainingHistory(
+            Losses: [3.5f, 2.25f, 1.125f],
+            TokensSeen: [4, 9, 13],
+            RunBoundaries: [2, 3],
+            CorpusTokenCount: 13,
+            PositionSeen: positionSeen,
+            VocabSeen: vocabSeen);
+        var dir = Path.Combine(_testDirectory, "ckpt");
+
+        await _service.SaveTrainingHistoryAsync(dir, history);
+        var loaded = await _service.TryLoadTrainingHistoryAsync(dir);
+
+        loaded.Should().NotBeNull();
+        loaded!.Losses.Should().Equal(3.5f, 2.25f, 1.125f);
+        loaded.TokensSeen.Should().Equal(4, 9, 13);
+        loaded.RunBoundaries.Should().Equal(2, 3);
+        loaded.CorpusTokenCount.Should().Be(13);
+        loaded.PositionSeen.Should().Equal(positionSeen);
+        loaded.VocabSeen.Should().Equal(vocabSeen);
+    }
+
+    [Fact]
+    public async Task SaveThenLoadTrainingHistory_ShouldRoundTripEmptySeries()
+    {
+        var history = new TrainingHistory([], [], [], CorpusTokenCount: 0, PositionSeen: [], VocabSeen: []);
+        var dir = Path.Combine(_testDirectory, "ckpt");
+
+        await _service.SaveTrainingHistoryAsync(dir, history);
+        var loaded = await _service.TryLoadTrainingHistoryAsync(dir);
+
+        loaded.Should().NotBeNull();
+        loaded!.Losses.Should().BeEmpty();
+        loaded.TokensSeen.Should().BeEmpty();
+        loaded.RunBoundaries.Should().BeEmpty();
+        loaded.PositionSeen.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TryLoadTrainingHistoryAsync_ShouldReturnNull_WhenFileAbsent()
+    {
+        var loaded = await _service.TryLoadTrainingHistoryAsync(Path.Combine(_testDirectory, "no-history"));
+
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryLoadTrainingHistoryAsync_ShouldThrow_WhenFormatVersionIsUnknown()
+    {
+        var dir = Path.Combine(_testDirectory, "ckpt");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllBytesAsync(Path.Combine(dir, "history.bin"), BitConverter.GetBytes(99));
+
+        var act = async () => await _service.TryLoadTrainingHistoryAsync(dir);
+
+        await act.Should().ThrowAsync<InvalidDataException>().WithMessage("*version 99*");
+    }
 }

--- a/Pixelbadger.Toolkit.Tests/GptCommandIntegrationTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptCommandIntegrationTests.cs
@@ -147,4 +147,94 @@ public class GptCommandIntegrationTests : IDisposable
 
         completeExit.Should().Be(0);
     }
+
+    [Fact]
+    public async Task GptCommand_ShouldWriteLossGraphWithOnePointPerStep_WhenLossGraphRequested()
+    {
+        var corpusPath = Path.Combine(_testDirectory, "corpus.txt");
+        await File.WriteAllTextAsync(corpusPath, string.Concat(Enumerable.Repeat("graph my loss. ", 30)));
+        var modelDir = Path.Combine(_testDirectory, "model");
+        var graphPath = Path.Combine(_testDirectory, "reports", "loss.html");
+
+        var trainExit = await GptCommand.Create().Parse(new[]
+        {
+            "train",
+            "--source", corpusPath,
+            "--out", modelDir,
+            "--loss-graph", graphPath,
+            "--steps", "7",
+            "--batch-size", "4",
+            "--block-size", "8",
+            "--n-embd", "16",
+            "--n-head", "2",
+            "--n-layer", "1",
+            "--seed", "1"
+        }).InvokeAsync();
+
+        trainExit.Should().Be(0);
+        File.Exists(graphPath).Should().BeTrue();
+
+        var html = await File.ReadAllTextAsync(graphPath);
+        html.Should().StartWith("<!DOCTYPE html>");
+
+        const string marker = "const LOSSES = [";
+        int start = html.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        int end = html.IndexOf(']', start);
+        html[start..end].Split(',').Should().HaveCount(7, "every training step must appear in the graph data");
+    }
+
+    [Fact]
+    public async Task GptCommand_ShouldGraphFullHistoryAcrossRuns_WhenResuming()
+    {
+        var corpusPath = Path.Combine(_testDirectory, "corpus.txt");
+        await File.WriteAllTextAsync(corpusPath, string.Concat(Enumerable.Repeat("keep my whole history. ", 30)));
+        var modelDir = Path.Combine(_testDirectory, "model");
+        var graphPath = Path.Combine(_testDirectory, "loss.html");
+
+        string[] TrainArgs(params string[] extra) => new[]
+        {
+            "train",
+            "--source", corpusPath,
+            "--out", modelDir,
+            "--loss-graph", graphPath,
+            "--batch-size", "4",
+            "--block-size", "8",
+            "--n-embd", "16",
+            "--n-head", "2",
+            "--n-layer", "1",
+            "--seed", "1"
+        }.Concat(extra).ToArray();
+
+        var firstExit = await GptCommand.Create().Parse(TrainArgs("--steps", "6")).InvokeAsync();
+        firstExit.Should().Be(0);
+        File.Exists(Path.Combine(modelDir, "history.bin")).Should().BeTrue();
+
+        var firstRunLosses = ReadSeries(await File.ReadAllTextAsync(graphPath), "const LOSSES = [");
+        firstRunLosses.Should().HaveCount(6);
+
+        var resumeExit = await GptCommand.Create().Parse(TrainArgs("--steps", "4", "--resume")).InvokeAsync();
+        resumeExit.Should().Be(0);
+
+        var html = await File.ReadAllTextAsync(graphPath);
+        var losses = ReadSeries(html, "const LOSSES = [");
+        var tokensSeen = ReadSeries(html, "const TOKENS_SEEN = [");
+
+        losses.Should().HaveCount(10, "the resumed graph must span both runs");
+        losses.Take(6).Should().Equal(firstRunLosses, "the first run's losses are preserved verbatim");
+        tokensSeen.Should().HaveCount(10);
+        ReadSeries(html, "const RUN_BOUNDARIES = [").Should().Equal("6", "10");
+
+        // Coverage is cumulative across runs, so it can only ever grow.
+        var counts = tokensSeen.Select(int.Parse).ToArray();
+        counts.Should().BeInAscendingOrder();
+        counts[6].Should().BeGreaterThanOrEqualTo(counts[5], "the resumed run continues from the visited positions");
+    }
+
+    private static string[] ReadSeries(string html, string marker)
+    {
+        int start = html.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        int end = html.IndexOf(']', start);
+        var body = html[start..end];
+        return body.Length == 0 ? Array.Empty<string>() : body.Split(',');
+    }
 }

--- a/Pixelbadger.Toolkit.Tests/GptTrainComponentTests.cs
+++ b/Pixelbadger.Toolkit.Tests/GptTrainComponentTests.cs
@@ -8,11 +8,12 @@ namespace Pixelbadger.Toolkit.Tests;
 public class GptTrainComponentTests
 {
     private readonly Mock<ICheckpointService> _mockCheckpoint = new();
+    private readonly Mock<ILossGraphService> _mockLossGraph = new();
     private readonly GptTrainComponent _component;
 
     public GptTrainComponentTests()
     {
-        _component = new GptTrainComponent(_mockCheckpoint.Object);
+        _component = new GptTrainComponent(_mockCheckpoint.Object, _mockLossGraph.Object);
     }
 
     [Fact]
@@ -136,6 +137,102 @@ public class GptTrainComponentTests
     }
 
     [Fact]
+    public async Task TrainAsync_ShouldPersistTrainingHistoryWithTheCheckpoint()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+        var options = new GptTrainOptions(Steps: 4, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 2);
+
+        TrainingHistory? saved = null;
+        _mockCheckpoint
+            .Setup(x => x.SaveTrainingHistoryAsync("out", It.IsAny<TrainingHistory>()))
+            .Callback<string, TrainingHistory>((_, history) => saved = history)
+            .Returns(Task.CompletedTask);
+
+        var result = await _component.TrainAsync(corpus, "out", options);
+
+        saved.Should().NotBeNull();
+        saved!.Losses.Should().Equal(result.LossHistory);
+        saved.TokensSeen.Should().Equal(result.TokensSeenHistory);
+        saved.RunBoundaries.Should().Equal(4);
+        saved.CorpusTokenCount.Should().Be(result.CorpusTokenCount);
+        saved.PositionSeen.Should().HaveCount(result.CorpusTokenCount);
+        saved.PositionSeen.Count(seen => seen).Should().Be(result.TokensSeen);
+        saved.VocabSeen.Count(seen => seen).Should().Be(result.VocabEntriesSeen);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldAppendToStoredHistory_WhenResuming()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20)); // 120 tokens
+        var checkpoint = CreateCheckpoint(corpus);
+        _mockCheckpoint.Setup(x => x.LoadAsync("ckpt")).ReturnsAsync(checkpoint);
+        _mockCheckpoint.Setup(x => x.TryLoadOptimizerStateAsync("ckpt")).ReturnsAsync((AdamWState?)null);
+
+        // A prior run of 5 steps that had already visited the first 30 corpus positions.
+        var positionSeen = new bool[120];
+        for (int i = 0; i < 30; i++)
+            positionSeen[i] = true;
+        var priorHistory = new TrainingHistory(
+            Losses: new[] { 3f, 2.9f, 2.8f, 2.7f, 2.6f },
+            TokensSeen: new[] { 9, 15, 21, 27, 30 },
+            RunBoundaries: new[] { 5 },
+            CorpusTokenCount: 120,
+            PositionSeen: positionSeen,
+            VocabSeen: new bool[checkpoint.Config.VocabSize]);
+        _mockCheckpoint.Setup(x => x.TryLoadTrainingHistoryAsync("ckpt")).ReturnsAsync(priorHistory);
+
+        var result = await _component.TrainAsync(
+            corpus, "ckpt", new GptTrainOptions(Steps: 6, BatchSize: 2, Resume: true, LossGraphPath: "loss.html"));
+
+        result.Steps.Should().Be(6, "Steps reports this run only");
+        result.TotalSteps.Should().Be(11, "the history spans both runs");
+        result.LossHistory.Should().HaveCount(11);
+        result.LossHistory.Take(5).Should().Equal(priorHistory.Losses, "the earlier run's losses are preserved");
+        result.TokensSeenHistory.Take(5).Should().Equal(priorHistory.TokensSeen);
+        result.RunBoundaries.Should().Equal(5, 11);
+        result.TokensSeen.Should().BeGreaterThan(30, "coverage continues from the positions already visited");
+        result.TokensSeenHistory[5].Should().BeGreaterThanOrEqualTo(30);
+        result.TokensSeenHistory.Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldRestartCoverageButKeepLosses_WhenResumedCorpusLengthDiffers()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20)); // 120 tokens
+        var checkpoint = CreateCheckpoint(corpus);
+        _mockCheckpoint.Setup(x => x.LoadAsync("ckpt")).ReturnsAsync(checkpoint);
+        _mockCheckpoint.Setup(x => x.TryLoadOptimizerStateAsync("ckpt")).ReturnsAsync((AdamWState?)null);
+
+        // History recorded against a different (shorter) corpus: its visited positions do not apply here.
+        var priorHistory = new TrainingHistory(
+            Losses: new[] { 3f, 2.5f },
+            TokensSeen: new[] { 40, 60 },
+            RunBoundaries: new[] { 2 },
+            CorpusTokenCount: 60,
+            PositionSeen: Enumerable.Repeat(true, 60).ToArray(),
+            VocabSeen: Enumerable.Repeat(true, checkpoint.Config.VocabSize).ToArray());
+        _mockCheckpoint.Setup(x => x.TryLoadTrainingHistoryAsync("ckpt")).ReturnsAsync(priorHistory);
+
+        var result = await _component.TrainAsync(
+            corpus, "ckpt", new GptTrainOptions(Steps: 2, BatchSize: 1, Resume: true));
+
+        result.LossHistory.Should().HaveCount(4);
+        result.LossHistory.Take(2).Should().Equal(priorHistory.Losses);
+        result.CorpusTokenCount.Should().Be(120);
+        result.TokensSeen.Should().BeLessThanOrEqualTo(18, "coverage restarted, so only this run's two windows count");
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldNotLoadStoredHistory_WhenNotResuming()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+
+        await _component.TrainAsync(corpus, "out", new GptTrainOptions(Steps: 2, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1));
+
+        _mockCheckpoint.Verify(x => x.TryLoadTrainingHistoryAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public async Task TrainAsync_ShouldThrow_WhenResumeCorpusContainsUnknownCharacters()
     {
         var checkpoint = CreateCheckpoint(string.Concat(Enumerable.Repeat("abcde ", 20)));
@@ -149,12 +246,99 @@ public class GptTrainComponentTests
     }
 
     [Fact]
+    public async Task TrainAsync_ShouldRecordLossForEveryStep()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+        var options = new GptTrainOptions(Steps: 12, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 5);
+
+        var reported = new List<float>();
+        var result = await _component.TrainAsync(corpus, "out", options, (_, loss) => reported.Add(loss));
+
+        result.LossHistory.Should().HaveCount(12);
+        result.LossHistory.Should().Equal(reported, "the history must hold the same per-step losses that were reported");
+        result.LossHistory[^1].Should().Be(result.FinalLoss);
+        result.LossGraphPath.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldWriteLossGraph_WhenGraphPathProvided()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+        var options = new GptTrainOptions(
+            Steps: 4, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 5,
+            LossGraphPath: "loss.html");
+
+        LossGraphReport? captured = null;
+        _mockLossGraph
+            .Setup(x => x.WriteAsync("loss.html", It.IsAny<LossGraphReport>()))
+            .Callback<string, LossGraphReport>((_, report) => captured = report)
+            .Returns(Task.CompletedTask);
+
+        var result = await _component.TrainAsync(corpus, "out", options);
+
+        result.LossGraphPath.Should().Be("loss.html");
+        _mockLossGraph.Verify(x => x.WriteAsync("loss.html", It.IsAny<LossGraphReport>()), Times.Once);
+        captured.Should().NotBeNull();
+        captured!.Losses.Should().Equal(result.LossHistory);
+        captured.BatchSize.Should().Be(2);
+        captured.LearningRate.Should().Be(options.LearningRate);
+        captured.VocabSize.Should().Be(result.VocabSize);
+        captured.ParameterCount.Should().Be(result.ParameterCount);
+        captured.CheckpointPath.Should().Be("out");
+        captured.Resumed.Should().BeFalse();
+        captured.TokensSeen.Should().Equal(result.TokensSeenHistory);
+        captured.VocabEntriesSeen.Should().Be(result.VocabEntriesSeen);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldCountDistinctCorpusPositionsSampled()
+    {
+        // 4 steps x 1 window of 8 inputs + 1 shifted target = at most 36 distinct positions.
+        var corpus = string.Concat(Enumerable.Repeat("abcdefgh ", 40));
+        var options = new GptTrainOptions(Steps: 4, BatchSize: 1, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 7);
+
+        var result = await _component.TrainAsync(corpus, "out", options);
+
+        result.TokensSeenHistory.Should().HaveCount(4);
+        result.TokensSeenHistory.Should().BeInAscendingOrder("coverage is cumulative and can never shrink");
+        result.TokensSeenHistory[0].Should().Be(9, "the first window covers block-size inputs plus one target");
+        result.TokensSeenHistory[^1].Should().Be(result.TokensSeen);
+        result.TokensSeen.Should().BeInRange(9, 36);
+        result.TokensSeen.Should().BeLessThan(result.CorpusTokenCount, "4 tiny windows cannot cover this corpus");
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldCoverWholeCorpusAndVocabulary_WhenGivenEnoughSteps()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20)); // 120 tokens, 6 distinct chars
+        var options = new GptTrainOptions(
+            Steps: 200, BatchSize: 8, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1, Seed: 3, Tokenizer: TokenizerKind.Char);
+
+        var result = await _component.TrainAsync(corpus, "out", options);
+
+        result.CorpusTokenCount.Should().Be(120);
+        result.TokensSeen.Should().Be(120, "200 steps of 8 random windows must reach every position of a 120-token corpus");
+        result.VocabEntriesSeen.Should().Be(result.VocabSize);
+    }
+
+    [Fact]
+    public async Task TrainAsync_ShouldNotWriteLossGraph_WhenGraphPathOmitted()
+    {
+        var corpus = string.Concat(Enumerable.Repeat("abcde ", 20));
+        var options = new GptTrainOptions(Steps: 3, BatchSize: 2, BlockSize: 8, NEmbd: 8, NHead: 2, NLayer: 1);
+
+        await _component.TrainAsync(corpus, "out", options);
+
+        _mockLossGraph.Verify(x => x.WriteAsync(It.IsAny<string>(), It.IsAny<LossGraphReport>()), Times.Never);
+    }
+
+    [Fact]
     public void SampleBatch_ShouldProduceTargetsShiftedByOne()
     {
         var data = Enumerable.Range(0, 20).ToArray();
         var rng = new Random(0);
 
-        var (inputs, targets) = GptTrainComponent.SampleBatch(data, batchSize: 3, blockSize: 4, rng);
+        var (inputs, targets, starts) = GptTrainComponent.SampleBatch(data, batchSize: 3, blockSize: 4, rng);
 
         inputs.Should().HaveCount(3);
         targets.Should().HaveCount(3);
@@ -163,6 +347,14 @@ public class GptTrainComponentTests
             inputs[b].Should().HaveCount(4);
             for (int t = 0; t < 4; t++)
                 targets[b][t].Should().Be(inputs[b][t] + 1); // data is the identity sequence
+        }
+
+        // data is the identity sequence, so each window's first token is its start offset.
+        starts.Should().HaveCount(3);
+        for (int b = 0; b < 3; b++)
+        {
+            starts[b].Should().Be(inputs[b][0]);
+            starts[b].Should().BeInRange(0, data.Length - 5);
         }
     }
 }

--- a/Pixelbadger.Toolkit.Tests/LossGraphServiceTests.cs
+++ b/Pixelbadger.Toolkit.Tests/LossGraphServiceTests.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Pixelbadger.Toolkit.Services;
+
+namespace Pixelbadger.Toolkit.Tests;
+
+public class LossGraphServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly LossGraphService _service = new();
+
+    public LossGraphServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+            Directory.Delete(_testDirectory, true);
+    }
+
+    private static LossGraphReport CreateReport(
+        IReadOnlyList<float> losses,
+        string checkpointPath = "./.gpt",
+        IReadOnlyList<int>? tokensSeen = null,
+        int vocabEntriesSeen = 250,
+        IReadOnlyList<int>? runBoundaries = null) =>
+        new(losses,
+            // Default coverage: a fixed 1000 positions per step, capped at the corpus size.
+            tokensSeen ?? Enumerable.Range(1, losses.Count).Select(i => Math.Min(i * 1000, 12345)).ToArray(),
+            runBoundaries ?? new[] { losses.Count },
+            new GptConfig(VocabSize: 300, BlockSize: 64, NEmbd: 128, NHead: 4, NLayer: 3),
+            BatchSize: 16,
+            LearningRate: 3e-4f,
+            VocabSize: 300,
+            VocabEntriesSeen: vocabEntriesSeen,
+            CorpusTokenCount: 12345,
+            ParameterCount: 678901,
+            CheckpointPath: checkpointPath,
+            Resumed: false);
+
+    [Fact]
+    public async Task WriteAsync_ShouldWriteSelfContainedHtmlFile()
+    {
+        var path = Path.Combine(_testDirectory, "loss.html");
+
+        await _service.WriteAsync(path, CreateReport(new[] { 4.2f, 3.1f, 2.5f }));
+
+        File.Exists(path).Should().BeTrue();
+        var html = await File.ReadAllTextAsync(path);
+        html.Should().StartWith("<!DOCTYPE html>");
+        html.Should().Contain("</html>");
+        html.Should().NotContain("http://").And.NotContain("https://", "the report must not load external resources");
+    }
+
+    [Fact]
+    public async Task WriteAsync_ShouldCreateMissingDirectories()
+    {
+        var path = Path.Combine(_testDirectory, "reports", "nested", "loss.html");
+
+        await _service.WriteAsync(path, CreateReport(new[] { 1.0f }));
+
+        File.Exists(path).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ShouldOverwriteExistingFile()
+    {
+        var path = Path.Combine(_testDirectory, "loss.html");
+        await File.WriteAllTextAsync(path, "stale");
+
+        await _service.WriteAsync(path, CreateReport(new[] { 1.5f, 1.25f }));
+
+        var html = await File.ReadAllTextAsync(path);
+        html.Should().NotContain("stale");
+        html.Should().Contain("[1.5,1.25]");
+    }
+
+    [Fact]
+    public void Render_ShouldEmbedEveryStepInOrder()
+    {
+        var losses = Enumerable.Range(0, 500).Select(i => 4f - i * 0.001f).ToArray();
+
+        var html = LossGraphService.Render(CreateReport(losses));
+
+        var series = ExtractSeries(html);
+        series.Should().HaveCount(500);
+        series[0].Should().Be("4");
+        series[^1].Should().Be("3.501");
+    }
+
+    [Fact]
+    public void Render_ShouldEmitNullForNonFiniteLosses()
+    {
+        var html = LossGraphService.Render(CreateReport(new[] { 2f, float.NaN, float.PositiveInfinity, 1.5f }));
+
+        ExtractSeries(html).Should().Equal("2", "null", "null", "1.5");
+    }
+
+    [Fact]
+    public void Render_ShouldReportStepCountAndLossSummary()
+    {
+        var html = LossGraphService.Render(CreateReport(new[] { 4.5f, 2.25f, 3f }));
+
+        html.Should().Contain(">3</div>", "the step count is shown as a stat");
+        html.Should().Contain("4.5000");  // first loss
+        html.Should().Contain("3.0000");  // final loss
+        html.Should().Contain("2.2500");  // best loss
+    }
+
+    [Fact]
+    public void Render_ShouldReportRunConfiguration()
+    {
+        var html = LossGraphService.Render(CreateReport(new[] { 1f }));
+
+        html.Should().Contain("678,901");   // parameter count
+        html.Should().Contain("12,345");    // corpus tokens
+        html.Should().Contain("0.0003");    // learning rate
+        html.Should().Contain("./.gpt");    // checkpoint path
+    }
+
+    [Fact]
+    public void Render_ShouldEmbedCumulativeTokensSeenPerStep()
+    {
+        var report = CreateReport(new[] { 3f, 2f, 1f }, tokensSeen: new[] { 500, 900, 1200 });
+
+        var html = LossGraphService.Render(report);
+
+        html.Should().Contain("const TOKENS_SEEN = [500,900,1200];");
+        html.Should().Contain("const CORPUS_TOKENS = 12345;");
+    }
+
+    [Fact]
+    public void Render_ShouldEmbedRunBoundariesAndRunCount()
+    {
+        var losses = Enumerable.Repeat(1f, 30).ToArray();
+
+        var html = LossGraphService.Render(CreateReport(losses, runBoundaries: new[] { 10, 25, 30 }));
+
+        html.Should().Contain("const RUN_BOUNDARIES = [10,25,30];");
+        html.Should().Contain("<div class=\"label\">Runs</div><div class=\"value\">3</div>");
+        html.Should().Contain("<tr><td>Training runs</td><td>3</td></tr>");
+    }
+
+    [Fact]
+    public void Render_ShouldReportCorpusAndVocabCoverage()
+    {
+        var report = CreateReport(new[] { 3f, 2f }, tokensSeen: new[] { 6000, 9876 }, vocabEntriesSeen: 210);
+
+        var html = LossGraphService.Render(report);
+
+        html.Should().Contain("Corpus coverage");
+        html.Should().Contain(">80.0%</div>", "9,876 of 12,345 corpus tokens were sampled");
+        html.Should().Contain("Vocab coverage");
+        html.Should().Contain(">70.0%</div>", "210 of 300 vocabulary entries were sampled");
+        html.Should().Contain("9,876 of 12,345 (80.0%)");
+        html.Should().Contain("210 of 300 (70.0%)");
+    }
+
+    [Fact]
+    public void Render_ShouldHtmlEncodeCheckpointPath()
+    {
+        var html = LossGraphService.Render(CreateReport(new[] { 1f }, "<script>alert(1)</script>"));
+
+        html.Should().NotContain("<script>alert(1)</script>");
+        html.Should().Contain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    }
+
+    [Fact]
+    public void Render_ShouldProduceEmptySeriesAndNoLossStats_WhenNoStepsRecorded()
+    {
+        var html = LossGraphService.Render(CreateReport(Array.Empty<float>()));
+
+        html.Should().Contain("const LOSSES = [];");
+        html.Should().Contain("const TOKENS_SEEN = [];");
+        html.Should().Contain("n/a");
+    }
+
+    /// <summary>Pulls the embedded <c>const LOSSES = [...]</c> array back out of the rendered page.</summary>
+    private static string[] ExtractSeries(string html)
+    {
+        const string marker = "const LOSSES = [";
+        int start = html.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        int end = html.IndexOf(']', start);
+        var body = html[start..end];
+        return body.Length == 0 ? Array.Empty<string>() : body.Split(',');
+    }
+}

--- a/Pixelbadger.Toolkit/Commands/GptCommand.cs
+++ b/Pixelbadger.Toolkit/Commands/GptCommand.cs
@@ -45,6 +45,7 @@ public static class GptCommand
         var resumeOption = new Option<bool>("--resume") { Description = "Resume training from the checkpoint in --out (architecture and tokenizer options are taken from the checkpoint)" };
         var tokenizerOption = new Option<TokenizerKind>("--tokenizer") { Description = "Tokenizer: bpe (byte-pair subwords) or char (one token per character)", DefaultValueFactory = _ => TokenizerKind.Bpe };
         var vocabSizeOption = new Option<int>("--vocab-size") { Description = "Target vocabulary size for the bpe tokenizer (>= 256; ignored for char)", DefaultValueFactory = _ => 512 };
+        var lossGraphOption = new Option<string?>("--loss-graph") { Description = "Path to write an HTML graph of the per-step training loss" };
 
         command.Add(sourceOption);
         command.Add(outOption);
@@ -59,6 +60,7 @@ public static class GptCommand
         command.Add(resumeOption);
         command.Add(tokenizerOption);
         command.Add(vocabSizeOption);
+        command.Add(lossGraphOption);
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
@@ -77,11 +79,12 @@ public static class GptCommand
                     Seed: parseResult.GetValue(seedOption),
                     Resume: parseResult.GetValue(resumeOption),
                     Tokenizer: parseResult.GetValue(tokenizerOption),
-                    VocabSize: parseResult.GetValue(vocabSizeOption));
+                    VocabSize: parseResult.GetValue(vocabSizeOption),
+                    LossGraphPath: parseResult.GetValue(lossGraphOption));
 
                 var corpus = await ResolveTextOrFilePath(source);
 
-                var component = new GptTrainComponent(new CheckpointService());
+                var component = new GptTrainComponent(new CheckpointService(), new LossGraphService());
                 var result = await component.TrainAsync(corpus, outDir, options, (step, loss) =>
                 {
                     if (step == 1 || step % 100 == 0 || step == options.Steps)
@@ -92,6 +95,18 @@ public static class GptCommand
                 AnsiConsole.MarkupLine(
                     $"[green]Trained[/] {result.ParameterCount:N0} params (vocab {result.VocabSize}) — final loss {result.FinalLoss:F4}. " +
                     $"Corpus: {result.CorpusTokenCount:N0} tokens ({charsPerToken:F2} chars/token). Checkpoint: {Markup.Escape(result.CheckpointPath)}");
+
+                var corpusCoverage = result.CorpusTokenCount > 0 ? 100d * result.TokensSeen / result.CorpusTokenCount : 0d;
+                var vocabCoverage = result.VocabSize > 0 ? 100d * result.VocabEntriesSeen / result.VocabSize : 0d;
+                var across = result.RunBoundaries.Count > 1
+                    ? $" across {result.RunBoundaries.Count} runs ({result.TotalSteps:N0} steps)"
+                    : string.Empty;
+                AnsiConsole.MarkupLine(
+                    $"[grey]Sampled[/] {result.TokensSeen:N0}/{result.CorpusTokenCount:N0} corpus tokens ({corpusCoverage:F1}%), " +
+                    $"{result.VocabEntriesSeen:N0}/{result.VocabSize:N0} vocab entries ({vocabCoverage:F1}%){across}");
+
+                if (result.LossGraphPath is not null)
+                    AnsiConsole.MarkupLine($"[green]Loss graph:[/] {Markup.Escape(Path.GetFullPath(result.LossGraphPath))}");
             }
             catch (Exception ex)
             {

--- a/Pixelbadger.Toolkit/Components/GptTrainComponent.cs
+++ b/Pixelbadger.Toolkit/Components/GptTrainComponent.cs
@@ -2,7 +2,29 @@ using Pixelbadger.Toolkit.Services;
 
 namespace Pixelbadger.Toolkit.Components;
 
-public record GptTrainResult(int Steps, float FinalLoss, string CheckpointPath, int ParameterCount, int VocabSize, int CorpusTokenCount);
+/// <param name="Steps">Steps run this time; a resumed run's history also covers the earlier runs.</param>
+/// <param name="LossHistory">Loss for every training step of every run against this checkpoint, in order.</param>
+/// <param name="TokensSeenHistory">Cumulative count of distinct corpus positions sampled, per step.</param>
+/// <param name="RunBoundaries">Cumulative step counts at the end of each run, including this one.</param>
+/// <param name="TokensSeen">Distinct corpus positions sampled so far, out of <paramref name="CorpusTokenCount"/>.</param>
+/// <param name="VocabEntriesSeen">Distinct vocabulary entries sampled so far, out of <paramref name="VocabSize"/>.</param>
+public record GptTrainResult(
+    int Steps,
+    float FinalLoss,
+    string CheckpointPath,
+    int ParameterCount,
+    int VocabSize,
+    int CorpusTokenCount,
+    IReadOnlyList<float> LossHistory,
+    IReadOnlyList<int> TokensSeenHistory,
+    IReadOnlyList<int> RunBoundaries,
+    int TokensSeen,
+    int VocabEntriesSeen,
+    string? LossGraphPath = null)
+{
+    /// <summary>Steps accumulated across every run that has trained this checkpoint.</summary>
+    public int TotalSteps => LossHistory.Count;
+}
 
 public record GptTrainOptions(
     int Steps = 2000,
@@ -15,21 +37,26 @@ public record GptTrainOptions(
     int Seed = 1337,
     bool Resume = false,
     TokenizerKind Tokenizer = TokenizerKind.Bpe,
-    int VocabSize = 512);
+    int VocabSize = 512,
+    string? LossGraphPath = null);
 
 /// <summary>
 /// Trains a tiny char-level GPT from a text corpus by gradient descent and writes a checkpoint.
 /// With <see cref="GptTrainOptions.Resume"/> set, continues from the checkpoint in the output
 /// directory instead of initializing fresh weights (architecture options are then taken from
 /// the checkpoint, and saved optimizer state is restored when present).
+/// The loss of every step is recorded, and written out as an HTML graph when
+/// <see cref="GptTrainOptions.LossGraphPath"/> is set.
 /// </summary>
 public class GptTrainComponent
 {
     private readonly ICheckpointService _checkpointService;
+    private readonly ILossGraphService _lossGraphService;
 
-    public GptTrainComponent(ICheckpointService checkpointService)
+    public GptTrainComponent(ICheckpointService checkpointService, ILossGraphService lossGraphService)
     {
         _checkpointService = checkpointService;
+        _lossGraphService = lossGraphService;
     }
 
     public async Task<GptTrainResult> TrainAsync(
@@ -79,10 +106,60 @@ public class GptTrainComponent
 
         var rng = new Random(options.Seed);
 
+        // Resuming picks up the checkpoint's recorded history so the graph spans every run, not just this one.
+        var priorHistory = options.Resume
+            ? await _checkpointService.TryLoadTrainingHistoryAsync(outputDirectory)
+            : null;
+
+        // Batches are sampled from random offsets, so track which corpus positions and which vocabulary
+        // entries have been visited — a low coverage means much of the corpus never trained. The visited
+        // sets only carry over when the corpus is unchanged; otherwise they describe text this run is not
+        // training on, so coverage restarts from this run's samples.
+        bool coverageCarriesOver = priorHistory is not null
+            && priorHistory.CorpusTokenCount == data.Length
+            && priorHistory.VocabSeen.Length == config.VocabSize;
+
+        var positionSeen = coverageCarriesOver ? priorHistory!.PositionSeen : new bool[data.Length];
+        var vocabSeen = coverageCarriesOver ? priorHistory!.VocabSeen : new bool[config.VocabSize];
+        int positionsSeen = CountSet(positionSeen);
+        int vocabEntriesSeen = CountSet(vocabSeen);
+
+        // Every step's loss and coverage is retained so the emitted graph has full granularity.
+        var lossHistory = new List<float>(options.Steps + (priorHistory?.Losses.Length ?? 0));
+        var tokensSeenHistory = new List<int>(lossHistory.Capacity);
+        var runBoundaries = new List<int>();
+        if (priorHistory is not null)
+        {
+            lossHistory.AddRange(priorHistory.Losses);
+            tokensSeenHistory.AddRange(priorHistory.TokensSeen);
+            runBoundaries.AddRange(priorHistory.RunBoundaries);
+        }
+
         float lastLoss = 0f;
         for (int step = 1; step <= options.Steps; step++)
         {
-            var (inputs, targets) = SampleBatch(data, options.BatchSize, config.BlockSize, rng);
+            var (inputs, targets, starts) = SampleBatch(data, options.BatchSize, config.BlockSize, rng);
+
+            foreach (int start in starts)
+            {
+                // A window trains on its block-size inputs plus the final shifted target token.
+                for (int offset = 0; offset <= config.BlockSize; offset++)
+                {
+                    int position = start + offset;
+                    if (!positionSeen[position])
+                    {
+                        positionSeen[position] = true;
+                        positionsSeen++;
+                    }
+
+                    int token = data[position];
+                    if (!vocabSeen[token])
+                    {
+                        vocabSeen[token] = true;
+                        vocabEntriesSeen++;
+                    }
+                }
+            }
 
             model.ZeroGrad();
             var (_, loss) = model.Forward(inputs, targets);
@@ -90,19 +167,55 @@ public class GptTrainComponent
             optimizer.Step();
 
             lastLoss = loss.Data[0];
+            lossHistory.Add(lastLoss);
+            tokensSeenHistory.Add(positionsSeen);
             onProgress?.Invoke(step, lastLoss);
         }
 
+        runBoundaries.Add(lossHistory.Count);
+
         await _checkpointService.SaveAsync(outputDirectory, config, tokenizer.ExportState(), model.Parameters());
         await _checkpointService.SaveOptimizerStateAsync(outputDirectory, optimizer.ExportState());
+        await _checkpointService.SaveTrainingHistoryAsync(outputDirectory, new TrainingHistory(
+            lossHistory.ToArray(), tokensSeenHistory.ToArray(), runBoundaries.ToArray(),
+            data.Length, positionSeen, vocabSeen));
 
-        return new GptTrainResult(options.Steps, lastLoss, outputDirectory, model.ParameterCount(), tokenizer.VocabSize, data.Length);
+        int parameterCount = model.ParameterCount();
+
+        var lossGraphPath = string.IsNullOrWhiteSpace(options.LossGraphPath) ? null : options.LossGraphPath;
+        if (lossGraphPath is not null)
+        {
+            var report = new LossGraphReport(
+                lossHistory, tokensSeenHistory, runBoundaries, config, options.BatchSize, options.LearningRate,
+                tokenizer.VocabSize, vocabEntriesSeen, data.Length, parameterCount, outputDirectory, options.Resume);
+            await _lossGraphService.WriteAsync(lossGraphPath, report);
+        }
+
+        return new GptTrainResult(
+            options.Steps, lastLoss, outputDirectory, parameterCount, tokenizer.VocabSize, data.Length,
+            lossHistory, tokensSeenHistory, runBoundaries, positionsSeen, vocabEntriesSeen, lossGraphPath);
     }
 
-    internal static (int[][] Inputs, int[][] Targets) SampleBatch(int[] data, int batchSize, int blockSize, Random rng)
+    private static int CountSet(bool[] flags)
+    {
+        int count = 0;
+        foreach (var flag in flags)
+        {
+            if (flag)
+                count++;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Draws <paramref name="batchSize"/> random windows from the corpus. The window start offsets are
+    /// returned alongside the batch so the caller can track which corpus positions have been visited.
+    /// </summary>
+    internal static (int[][] Inputs, int[][] Targets, int[] Starts) SampleBatch(int[] data, int batchSize, int blockSize, Random rng)
     {
         var inputs = new int[batchSize][];
         var targets = new int[batchSize][];
+        var starts = new int[batchSize];
         int maxStart = data.Length - blockSize - 1;
 
         for (int b = 0; b < batchSize; b++)
@@ -117,8 +230,9 @@ public class GptTrainComponent
             }
             inputs[b] = inp;
             targets[b] = tgt;
+            starts[b] = start;
         }
 
-        return (inputs, targets);
+        return (inputs, targets, starts);
     }
 }

--- a/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
+++ b/Pixelbadger.Toolkit/Pixelbadger.Toolkit.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pbtk</ToolCommandName>
     <PackageId>Pixelbadger.Toolkit</PackageId>
-    <Version>6.7.0</Version>
+    <Version>6.8.0</Version>
     <Authors>Pixelbadger</Authors>
     <Description>A CLI toolkit exposing varied functionality organized by topic, including string manipulation, distance calculations, esoteric programming language interpreters, image steganography, web serving, LLM integration, homomorphic encryption, Markov chain text generation, and Amiga demoscene effects.</Description>
     <PackageTags>cli;toolkit;strings;interpreters;steganography;llm;openai;crypto;homomorphic-encryption;markov;text-generation;demoscene;amiga</PackageTags>

--- a/Pixelbadger.Toolkit/Services/CheckpointService.cs
+++ b/Pixelbadger.Toolkit/Services/CheckpointService.cs
@@ -11,6 +11,9 @@ public sealed class CheckpointService : ICheckpointService
     internal const string ConfigFileName = "config.json";
     internal const string WeightsFileName = "weights.bin";
     internal const string OptimizerFileName = "optimizer.bin";
+    internal const string HistoryFileName = "history.bin";
+
+    private const int HistoryFormatVersion = 1;
 
     private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
 
@@ -116,5 +119,99 @@ public sealed class CheckpointService : ICheckpointService
         }
 
         return Task.FromResult<AdamWState?>(new AdamWState(step, m, v));
+    }
+
+    public Task SaveTrainingHistoryAsync(string directory, TrainingHistory history)
+    {
+        Directory.CreateDirectory(directory);
+
+        using var stream = File.Create(Path.Combine(directory, HistoryFileName));
+        using var writer = new BinaryWriter(stream);
+        writer.Write(HistoryFormatVersion);
+        writer.Write(history.CorpusTokenCount);
+
+        writer.Write(history.Losses.Length);
+        foreach (var loss in history.Losses)
+            writer.Write(loss);
+        foreach (var seen in history.TokensSeen)
+            writer.Write(seen);
+
+        writer.Write(history.RunBoundaries.Length);
+        foreach (var boundary in history.RunBoundaries)
+            writer.Write(boundary);
+
+        WriteBitmap(writer, history.PositionSeen);
+        WriteBitmap(writer, history.VocabSeen);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TrainingHistory?> TryLoadTrainingHistoryAsync(string directory)
+    {
+        var path = Path.Combine(directory, HistoryFileName);
+        if (!File.Exists(path))
+            return Task.FromResult<TrainingHistory?>(null);
+
+        using var stream = File.OpenRead(path);
+        using var reader = new BinaryReader(stream);
+
+        int version = reader.ReadInt32();
+        if (version != HistoryFormatVersion)
+            throw new InvalidDataException(
+                $"Unsupported training history format (version {version}) in '{directory}'.");
+
+        int corpusTokenCount = reader.ReadInt32();
+
+        int steps = reader.ReadInt32();
+        var losses = new float[steps];
+        for (int i = 0; i < steps; i++)
+            losses[i] = reader.ReadSingle();
+        var tokensSeen = new int[steps];
+        for (int i = 0; i < steps; i++)
+            tokensSeen[i] = reader.ReadInt32();
+
+        int boundaryCount = reader.ReadInt32();
+        var boundaries = new int[boundaryCount];
+        for (int i = 0; i < boundaryCount; i++)
+            boundaries[i] = reader.ReadInt32();
+
+        var positionSeen = ReadBitmap(reader);
+        var vocabSeen = ReadBitmap(reader);
+
+        return Task.FromResult<TrainingHistory?>(
+            new TrainingHistory(losses, tokensSeen, boundaries, corpusTokenCount, positionSeen, vocabSeen));
+    }
+
+    /// <summary>Packs a visited-set flag array eight entries to the byte.</summary>
+    private static void WriteBitmap(BinaryWriter writer, bool[] flags)
+    {
+        writer.Write(flags.Length);
+        byte packed = 0;
+        for (int i = 0; i < flags.Length; i++)
+        {
+            if (flags[i])
+                packed |= (byte)(1 << (i % 8));
+            if (i % 8 == 7)
+            {
+                writer.Write(packed);
+                packed = 0;
+            }
+        }
+        if (flags.Length % 8 != 0)
+            writer.Write(packed);
+    }
+
+    private static bool[] ReadBitmap(BinaryReader reader)
+    {
+        int length = reader.ReadInt32();
+        var flags = new bool[length];
+        byte packed = 0;
+        for (int i = 0; i < length; i++)
+        {
+            if (i % 8 == 0)
+                packed = reader.ReadByte();
+            flags[i] = (packed & (1 << (i % 8))) != 0;
+        }
+        return flags;
     }
 }

--- a/Pixelbadger.Toolkit/Services/ICheckpointService.cs
+++ b/Pixelbadger.Toolkit/Services/ICheckpointService.cs
@@ -2,10 +2,30 @@ namespace Pixelbadger.Toolkit.Services;
 
 public record GptCheckpoint(GptConfig Config, TokenizerState Tokenizer, float[][] Weights);
 
+/// <summary>
+/// The training history accumulated across every run that has touched a checkpoint, so a resumed
+/// run can graph the whole curve rather than just its own steps.
+/// </summary>
+/// <param name="Losses">Loss for every step of every run, in order.</param>
+/// <param name="TokensSeen">Cumulative distinct corpus positions sampled, per step.</param>
+/// <param name="RunBoundaries">Cumulative step counts at the end of each completed run.</param>
+/// <param name="CorpusTokenCount">Token count of the corpus the coverage sets refer to.</param>
+/// <param name="PositionSeen">Which corpus positions have been sampled at least once.</param>
+/// <param name="VocabSeen">Which vocabulary entries have been sampled at least once.</param>
+public record TrainingHistory(
+    float[] Losses,
+    int[] TokensSeen,
+    int[] RunBoundaries,
+    int CorpusTokenCount,
+    bool[] PositionSeen,
+    bool[] VocabSeen);
+
 public interface ICheckpointService
 {
     Task SaveAsync(string directory, GptConfig config, TokenizerState tokenizer, IReadOnlyList<Tensor> parameters);
     Task<GptCheckpoint> LoadAsync(string directory);
     Task SaveOptimizerStateAsync(string directory, AdamWState state);
     Task<AdamWState?> TryLoadOptimizerStateAsync(string directory);
+    Task SaveTrainingHistoryAsync(string directory, TrainingHistory history);
+    Task<TrainingHistory?> TryLoadTrainingHistoryAsync(string directory);
 }

--- a/Pixelbadger.Toolkit/Services/ILossGraphService.cs
+++ b/Pixelbadger.Toolkit/Services/ILossGraphService.cs
@@ -1,0 +1,27 @@
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// A checkpoint's training history: the per-step loss series, the per-step count of distinct corpus
+/// positions sampled so far, where each run ended, and the latest run's configuration. Series span
+/// every run that has trained the checkpoint, not just the most recent one.
+/// </summary>
+public record LossGraphReport(
+    IReadOnlyList<float> Losses,
+    IReadOnlyList<int> TokensSeen,
+    IReadOnlyList<int> RunBoundaries,
+    GptConfig Config,
+    int BatchSize,
+    float LearningRate,
+    int VocabSize,
+    int VocabEntriesSeen,
+    int CorpusTokenCount,
+    int ParameterCount,
+    string CheckpointPath,
+    bool Resumed);
+
+/// <summary>Renders a training run's loss history as a standalone HTML report.</summary>
+public interface ILossGraphService
+{
+    /// <summary>Writes the loss graph for <paramref name="report"/> to <paramref name="outputPath"/>.</summary>
+    Task WriteAsync(string outputPath, LossGraphReport report);
+}

--- a/Pixelbadger.Toolkit/Services/LossGraphService.cs
+++ b/Pixelbadger.Toolkit/Services/LossGraphService.cs
@@ -1,0 +1,373 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+
+namespace Pixelbadger.Toolkit.Services;
+
+/// <summary>
+/// Writes a training run's per-step loss history to a standalone HTML file: the full series is
+/// embedded as a JSON array and drawn to a canvas by inline script, so the report needs no
+/// network access and stays readable for runs with tens of thousands of steps.
+/// </summary>
+public sealed class LossGraphService : ILossGraphService
+{
+    public async Task WriteAsync(string outputPath, LossGraphReport report)
+    {
+        var fullPath = Path.GetFullPath(outputPath);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(fullPath, Render(report));
+    }
+
+    /// <summary>Builds the report HTML. Exposed for testing without touching the file system.</summary>
+    internal static string Render(LossGraphReport report)
+    {
+        var losses = report.Losses;
+        var finite = losses.Where(float.IsFinite).ToList();
+
+        int tokensSeen = report.TokensSeen.Count > 0 ? report.TokensSeen[^1] : 0;
+
+        int runs = Math.Max(1, report.RunBoundaries.Count);
+
+        var stats = new StringBuilder();
+        AppendStat(stats, "Steps", losses.Count.ToString("N0", CultureInfo.InvariantCulture));
+        AppendStat(stats, "Runs", runs.ToString("N0", CultureInfo.InvariantCulture));
+        AppendStat(stats, "First loss", FormatLoss(finite.Count > 0 ? finite[0] : float.NaN));
+        AppendStat(stats, "Final loss", FormatLoss(finite.Count > 0 ? finite[^1] : float.NaN));
+        AppendStat(stats, "Best loss", FormatLoss(finite.Count > 0 ? finite.Min() : float.NaN));
+        AppendStat(stats, "Corpus coverage", FormatPercent(tokensSeen, report.CorpusTokenCount));
+        AppendStat(stats, "Vocab coverage", FormatPercent(report.VocabEntriesSeen, report.VocabSize));
+
+        var meta = new StringBuilder();
+        AppendMeta(meta, "Parameters", report.ParameterCount.ToString("N0", CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Vocab size", report.VocabSize.ToString("N0", CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Vocab entries seen", FormatSeen(report.VocabEntriesSeen, report.VocabSize));
+        AppendMeta(meta, "Corpus tokens", report.CorpusTokenCount.ToString("N0", CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Corpus tokens seen", FormatSeen(tokensSeen, report.CorpusTokenCount));
+        AppendMeta(meta, "Block size", report.Config.BlockSize.ToString(CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Batch size", report.BatchSize.ToString(CultureInfo.InvariantCulture));
+        AppendMeta(meta, "n-embd", report.Config.NEmbd.ToString(CultureInfo.InvariantCulture));
+        AppendMeta(meta, "n-head", report.Config.NHead.ToString(CultureInfo.InvariantCulture));
+        AppendMeta(meta, "n-layer", report.Config.NLayer.ToString(CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Learning rate", report.LearningRate.ToString("0.#######", CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Checkpoint", WebUtility.HtmlEncode(report.CheckpointPath));
+        AppendMeta(meta, "Training runs", runs.ToString("N0", CultureInfo.InvariantCulture));
+        AppendMeta(meta, "Latest run resumed", report.Resumed ? "yes" : "no");
+
+        var generated = WebUtility.HtmlEncode(
+            DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture));
+
+        return $$"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GPT Training Loss</title>
+<style>
+  :root {
+    --bg: #f8fafc; --panel: #ffffff; --border: #e2e8f0; --text: #0f172a;
+    --muted: #64748b; --grid: #e2e8f0; --raw: #94a3b8; --line: #2563eb; --best: #16a34a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a; --panel: #1e293b; --border: #334155; --text: #e2e8f0;
+      --muted: #94a3b8; --grid: #334155; --raw: #475569; --line: #60a5fa; --best: #4ade80;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2rem 1.25rem; background: var(--bg); color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  .wrap { max-width: 1000px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; margin: 0 0 .25rem; }
+  .sub { color: var(--muted); font-size: .875rem; margin: 0 0 1.5rem; }
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: .75rem; margin-bottom: 1.5rem; }
+  .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: .75rem 1rem; }
+  .stat .label { color: var(--muted); font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; }
+  .stat .value { font-size: 1.375rem; font-variant-numeric: tabular-nums; margin-top: .25rem; }
+  .chart {
+    position: relative; background: var(--panel); border: 1px solid var(--border);
+    border-radius: 8px; padding: .75rem; margin-bottom: 1.5rem;
+  }
+  .chart h2 { font-size: .9375rem; font-weight: 600; margin: .25rem .25rem .5rem; }
+  .chart h2 small { color: var(--muted); font-weight: 400; }
+  canvas { display: block; width: 100%; height: 320px; }
+  .legend { display: flex; gap: 1.25rem; flex-wrap: wrap; color: var(--muted); font-size: .8125rem; padding: .5rem .25rem 0; }
+  .legend span::before {
+    content: ""; display: inline-block; width: 14px; height: 3px; border-radius: 2px;
+    margin-right: .4rem; vertical-align: middle; background: currentColor;
+  }
+  .legend .raw { color: var(--raw); }
+  .legend .smooth { color: var(--line); }
+  .legend .divider { color: var(--muted); }
+  .legend .divider::before { background: repeating-linear-gradient(90deg, currentColor 0 4px, transparent 4px 8px); }
+  .tip {
+    position: absolute; pointer-events: none; display: none; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 6px; padding: .4rem .6rem;
+    font-size: .8125rem; font-variant-numeric: tabular-nums; white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0,0,0,.15);
+  }
+  table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  td { padding: .5rem .875rem; border-bottom: 1px solid var(--border); font-size: .875rem; }
+  tr:last-child td { border-bottom: none; }
+  td:first-child { color: var(--muted); width: 40%; }
+  td:last-child { font-variant-numeric: tabular-nums; word-break: break-all; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>GPT Training History</h1>
+  <p class="sub">Per-step loss and corpus coverage across every run against this checkpoint &mdash; generated {{generated}}</p>
+
+  <div class="stats">
+{{stats}}  </div>
+
+  <div class="chart">
+    <h2>Loss <small>&mdash; cross-entropy per step</small></h2>
+    <canvas id="loss-chart"></canvas>
+    <div class="tip" id="loss-tip"></div>
+    <div class="legend">
+      <span class="raw">per-step loss</span>
+      <span class="smooth">smoothed</span>
+      <span class="divider">run boundary</span>
+    </div>
+  </div>
+
+  <div class="chart">
+    <h2>Corpus coverage <small>&mdash; share of the corpus's {{report.CorpusTokenCount.ToString("N0", CultureInfo.InvariantCulture)}} token positions sampled at least once</small></h2>
+    <canvas id="coverage-chart"></canvas>
+    <div class="tip" id="coverage-tip"></div>
+    <div class="legend">
+      <span class="smooth">cumulative unique tokens visited</span>
+    </div>
+  </div>
+
+  <table>
+    <tbody>
+{{meta}}    </tbody>
+  </table>
+</div>
+
+<script>
+const LOSSES = [{{FormatSeries(losses)}}];
+const TOKENS_SEEN = [{{FormatCounts(report.TokensSeen)}}];
+const CORPUS_TOKENS = {{report.CorpusTokenCount.ToString(CultureInfo.InvariantCulture)}};
+// Cumulative step count at the end of each training run; all but the last mark a --resume point.
+const RUN_BOUNDARIES = [{{FormatCounts(report.RunBoundaries)}}];
+
+const PAD = { top: 16, right: 16, bottom: 32, left: 56 };
+const FONT = '11px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+const css = name => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+function extent(values) {
+  let min = Infinity, max = -Infinity;
+  for (const v of values) {
+    if (v === null) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return min === Infinity ? [0, 1] : [min, max];
+}
+
+// Exponential moving average; the window scales with run length so short and long runs both
+// read clearly. Non-finite losses (a diverged run) are carried through as null.
+function smooth(values) {
+  const alpha = 2 / (Math.max(1, Math.round(values.length / 100)) + 1);
+  const out = [];
+  let ema = null;
+  for (const v of values) {
+    if (v === null) { out.push(null); continue; }
+    ema = ema === null ? v : alpha * v + (1 - alpha) * ema;
+    out.push(ema);
+  }
+  return out;
+}
+
+/**
+ * Draws one line chart onto a canvas and wires up its hover readout.
+ * layers: [{ data, color, width }] over a shared step axis; opts.yLabel/opts.tipText format text.
+ */
+function chart(canvasId, tipId, layers, opts) {
+  const canvas = document.getElementById(canvasId);
+  const tip = document.getElementById(tipId);
+  const ctx = canvas.getContext('2d');
+  const steps = layers[0].data.length;
+
+  let lo, hi;
+  if (opts.yRange) {
+    [lo, hi] = opts.yRange;
+  } else {
+    const [min, max] = extent(layers.flatMap(l => l.data));
+    const pad = (max - min) * 0.08 || 0.5;
+    lo = Math.max(0, min - pad);
+    hi = max + pad;
+  }
+
+  let plot = { x: 0, y: 0, w: 0, h: 0 };
+  const xAt = i => plot.x + (steps <= 1 ? plot.w / 2 : (i / (steps - 1)) * plot.w);
+  const yAt = v => plot.y + plot.h - ((v - lo) / (hi - lo || 1)) * plot.h;
+
+  function stroke(values, color, width) {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    let open = false;
+    for (let i = 0; i < values.length; i++) {
+      const v = values[i];
+      if (v === null) { open = false; continue; }
+      const x = xAt(i), y = yAt(v);
+      if (open) ctx.lineTo(x, y); else { ctx.moveTo(x, y); open = true; }
+    }
+    ctx.stroke();
+  }
+
+  function draw() {
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth, h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+
+    plot = { x: PAD.left, y: PAD.top, w: w - PAD.left - PAD.right, h: h - PAD.top - PAD.bottom };
+    if (plot.w <= 0 || plot.h <= 0 || !steps) return;
+
+    ctx.font = FONT;
+    ctx.strokeStyle = css('--grid');
+    ctx.fillStyle = css('--muted');
+    ctx.lineWidth = 1;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let i = 0; i <= 5; i++) {
+      const v = lo + (hi - lo) * (i / 5);
+      const y = Math.round(yAt(v)) + 0.5;
+      ctx.beginPath();
+      ctx.moveTo(plot.x, y);
+      ctx.lineTo(plot.x + plot.w, y);
+      ctx.stroke();
+      ctx.fillText(opts.yLabel(v), plot.x - 8, y);
+    }
+
+    // Dashed divider wherever a run ended and a later --resume picked the checkpoint back up.
+    ctx.save();
+    ctx.setLineDash([4, 4]);
+    ctx.strokeStyle = css('--muted');
+    for (let b = 0; b < RUN_BOUNDARIES.length - 1; b++) {
+      const x = Math.round(xAt(RUN_BOUNDARIES[b] - 1)) + 0.5;
+      ctx.beginPath();
+      ctx.moveTo(x, plot.y);
+      ctx.lineTo(x, plot.y + plot.h);
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    const xTicks = Math.min(6, steps);
+    for (let i = 0; i < xTicks; i++) {
+      const idx = xTicks === 1 ? 0 : Math.round((i / (xTicks - 1)) * (steps - 1));
+      ctx.fillText(String(idx + 1), xAt(idx), plot.y + plot.h + 8);
+    }
+
+    for (const layer of layers) stroke(layer.data, css(layer.color), layer.width);
+  }
+
+  canvas.addEventListener('mousemove', e => {
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    if (!steps || x < plot.x || x > plot.x + plot.w) { tip.style.display = 'none'; draw(); return; }
+
+    const i = Math.max(0, Math.min(steps - 1, Math.round(((x - plot.x) / (plot.w || 1)) * (steps - 1))));
+    const v = layers[0].data[i];
+    draw();
+
+    ctx.strokeStyle = css('--muted');
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(Math.round(xAt(i)) + 0.5, plot.y);
+    ctx.lineTo(Math.round(xAt(i)) + 0.5, plot.y + plot.h);
+    ctx.stroke();
+
+    if (v !== null) {
+      ctx.fillStyle = css(layers[layers.length - 1].color);
+      ctx.beginPath();
+      ctx.arc(xAt(i), yAt(v), 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    tip.textContent = opts.tipText(i, v);
+    tip.style.display = 'block';
+    tip.style.left = Math.min(rect.width - tip.offsetWidth - 8, xAt(i) + 12) + 'px';
+    tip.style.top = (v === null ? plot.y : Math.max(plot.y, yAt(v) - 32)) + 'px';
+  });
+
+  canvas.addEventListener('mouseleave', () => { tip.style.display = 'none'; draw(); });
+  window.addEventListener('resize', draw);
+  if (window.matchMedia) window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', draw);
+  draw();
+}
+
+chart('loss-chart', 'loss-tip',
+  [{ data: LOSSES, color: '--raw', width: 1 }, { data: smooth(LOSSES), color: '--line', width: 2 }],
+  {
+    yLabel: v => v.toFixed(2),
+    tipText: (i, v) => 'step ' + (i + 1) + ' — loss ' + (v === null ? 'n/a' : v.toFixed(4))
+  });
+
+const coveragePct = TOKENS_SEEN.map(n => CORPUS_TOKENS ? (n / CORPUS_TOKENS) * 100 : 0);
+chart('coverage-chart', 'coverage-tip',
+  [{ data: coveragePct, color: '--line', width: 2 }],
+  {
+    yRange: [0, 100],
+    yLabel: v => v.toFixed(0) + '%',
+    tipText: (i, v) => 'step ' + (i + 1) + ' — ' + TOKENS_SEEN[i].toLocaleString() +
+      ' tokens (' + v.toFixed(1) + '%)'
+  });
+</script>
+</body>
+</html>
+
+""";
+    }
+
+    /// <summary>Emits the loss series as JSON numbers; non-finite values become <c>null</c> so the page can skip them.</summary>
+    private static string FormatSeries(IReadOnlyList<float> losses)
+    {
+        var builder = new StringBuilder(losses.Count * 8);
+        for (int i = 0; i < losses.Count; i++)
+        {
+            if (i > 0)
+                builder.Append(',');
+            builder.Append(float.IsFinite(losses[i])
+                ? losses[i].ToString("0.######", CultureInfo.InvariantCulture)
+                : "null");
+        }
+        return builder.ToString();
+    }
+
+    /// <summary>Emits the cumulative tokens-seen series as JSON integers.</summary>
+    private static string FormatCounts(IReadOnlyList<int> counts) =>
+        string.Join(',', counts.Select(c => c.ToString(CultureInfo.InvariantCulture)));
+
+    private static string FormatPercent(int seen, int total) =>
+        total > 0 ? (100d * seen / total).ToString("0.0", CultureInfo.InvariantCulture) + "%" : "n/a";
+
+    private static string FormatSeen(int seen, int total) =>
+        $"{seen.ToString("N0", CultureInfo.InvariantCulture)} of {total.ToString("N0", CultureInfo.InvariantCulture)} ({FormatPercent(seen, total)})";
+
+    private static string FormatLoss(float value) =>
+        float.IsFinite(value) ? value.ToString("0.0000", CultureInfo.InvariantCulture) : "n/a";
+
+    private static void AppendStat(StringBuilder builder, string label, string value) =>
+        builder.Append("    <div class=\"stat\"><div class=\"label\">").Append(WebUtility.HtmlEncode(label))
+            .Append("</div><div class=\"value\">").Append(value).AppendLine("</div></div>");
+
+    private static void AppendMeta(StringBuilder builder, string label, string value) =>
+        builder.Append("      <tr><td>").Append(WebUtility.HtmlEncode(label))
+            .Append("</td><td>").Append(value).AppendLine("</td></tr>");
+}

--- a/docs/gpt.html
+++ b/docs/gpt.html
@@ -97,7 +97,8 @@ flowchart TB
     MODEL["GptModel\n(decoder-only transformer)"]
     TENSOR["Tensor\n(reverse-mode autograd + SIMD kernels)"]
     OPT["AdamW\n(optimizer)"]
-    CKPT["CheckpointService\n(config.json + weights.bin)"]
+    CKPT["CheckpointService\n(config.json + weights.bin\n+ optimizer.bin + history.bin)"]
+    GRAPHS["LossGraphService\n(HTML loss + coverage report)"]
 
     CMD --> TRAINC
     CMD --> COMPC
@@ -105,6 +106,7 @@ flowchart TB
     TRAINC --> MODEL
     TRAINC --> OPT
     TRAINC --> CKPT
+    TRAINC --> GRAPHS
     COMPC --> TOK
     COMPC --> MODEL
     COMPC --> CKPT
@@ -125,7 +127,8 @@ flowchart TB
         <tr><td><code>GptModel</code> + <code>GptConfig</code></td><td>Services/</td><td>The decoder-only transformer: owns parameter tensors, weight initialization, and the forward pass producing logits and cross-entropy loss</td></tr>
         <tr><td><code>Tensor</code></td><td>Services/</td><td>Minimal reverse-mode automatic differentiation engine over 2D float matrices; every model op (matmul, layernorm, softmax, GELU, …) lives here with its backward function</td></tr>
         <tr><td><code>AdamW</code></td><td>Services/</td><td>AdamW optimizer with decoupled weight decay over the model's parameter list</td></tr>
-        <tr><td><code>CheckpointService</code></td><td>Services/</td><td>Persists and restores checkpoints behind the <code>ICheckpointService</code> interface (injected into both components for testability)</td></tr>
+        <tr><td><code>CheckpointService</code></td><td>Services/</td><td>Persists and restores checkpoints — weights, optimizer state, and the accumulated training history — behind the <code>ICheckpointService</code> interface (injected into both components for testability)</td></tr>
+        <tr><td><code>LossGraphService</code></td><td>Services/</td><td>Renders the recorded per-step loss and corpus-coverage series (across every run against the checkpoint) as a standalone HTML report behind the <code>ILossGraphService</code> interface (injected into <code>GptTrainComponent</code>); the full series is embedded in the page and drawn to a canvas by inline script</td></tr>
       </tbody>
     </table>
 
@@ -246,16 +249,17 @@ flowchart TB
     FWD --> BWD["loss.Backward()\n(reverse-mode autograd)"]
     BWD --> ADAM["AdamW.Step()\n(decoupled weight decay)"]
     ADAM --> LOOP
-    LOOP --> SAVE["CheckpointService.SaveAsync\n(config.json + weights.bin\n+ optimizer.bin)"]
+    LOOP --> SAVE["CheckpointService.SaveAsync\n(config.json + weights.bin\n+ optimizer.bin + history.bin)"]
+    SAVE --> GRAPH["LossGraphService.WriteAsync\n(HTML loss + coverage report,\nonly with --loss-graph)"]
       </div>
     </div>
 
     <ol>
       <li><strong>Tokenize</strong> — <code>Tokenizers.Build</code> builds the requested tokenizer (<code>--tokenizer bpe</code> learns byte-pair merges up to <code>--vocab-size</code>; <code>char</code> takes the sorted distinct characters), then encodes the whole corpus into one integer array. The corpus must encode to at least <code>block-size + 1</code> tokens.</li>
       <li><strong>Construct</strong> — a <code>GptModel</code> is built from the config and initialized from the seeded RNG; an <code>AdamW</code> instance is bound to the model's parameter list (learning rate from <code>--lr</code>; betas 0.9/0.95, weight decay 0.1). With <code>--resume</code>, the model, tokenizer, and config are instead loaded from the checkpoint in <code>--out</code> (architecture and tokenizer options are ignored), and saved AdamW moments are restored so training continues without a loss spike.</li>
-      <li><strong>Sample batches</strong> — each step draws <code>--batch-size</code> random windows of <code>--block-size</code> tokens; the target sequence is the same window shifted one token right, so every position learns next-token prediction simultaneously.</li>
-      <li><strong>Step</strong> — <code>ZeroGrad</code> &rarr; <code>Forward</code> (logits + loss) &rarr; <code>loss.Backward()</code> &rarr; <code>optimizer.Step()</code>. The command layer prints step/loss at step 1, every 100th step, and the final step.</li>
-      <li><strong>Persist</strong> — after the final step the checkpoint (config, tokenizer state, and all weight tensors in construction order) plus the optimizer state is written via <code>CheckpointService</code>, and a summary (parameter count, vocab size, final loss, corpus token count and chars/token, path) is reported.</li>
+      <li><strong>Sample batches</strong> — each step draws <code>--batch-size</code> random windows of <code>--block-size</code> tokens; the target sequence is the same window shifted one token right, so every position learns next-token prediction simultaneously. Each window's start offset is returned with the batch so the component can mark which corpus positions and which vocabulary entries have been visited &mdash; random sampling means coverage is probabilistic, and a run with too few steps will never see parts of the corpus.</li>
+      <li><strong>Step</strong> — <code>ZeroGrad</code> &rarr; <code>Forward</code> (logits + loss) &rarr; <code>loss.Backward()</code> &rarr; <code>optimizer.Step()</code>. The command layer prints step/loss at step 1, every 100th step, and the final step, while the component records every step's loss in full.</li>
+      <li><strong>Persist</strong> — after the final step the checkpoint (config, tokenizer state, and all weight tensors in construction order) plus the optimizer state is written via <code>CheckpointService</code>, the loss and coverage series (with the packed visited sets and run boundaries) are written to <code>history.bin</code> so a later <code>--resume</code> can continue them, and a summary (parameter count, vocab size, final loss, corpus token count and chars/token, path, plus corpus and vocabulary coverage) is reported. When <code>--loss-graph</code> is set, <code>LossGraphService</code> then writes the whole per-step loss and coverage series out as a standalone HTML report.</li>
     </ol>
   </section>
 
@@ -303,7 +307,7 @@ flowchart TB
     <h2>Checkpoint Format</h2>
     <p>
       A checkpoint is a directory (default <code>./.gpt</code>) written by <code>CheckpointService</code>
-      containing three files:
+      containing four files:
     </p>
 
     <table>
@@ -323,6 +327,11 @@ flowchart TB
           <td><code>optimizer.bin</code></td>
           <td>Little-endian binary</td>
           <td>AdamW state: step count (int32), tensor count (int32), then per tensor its length (int32) followed by the float32 first-moment then second-moment values. Used only by <code>--resume</code>; optional — a checkpoint without it resumes with a fresh optimizer</td>
+        </tr>
+        <tr>
+          <td><code>history.bin</code></td>
+          <td>Little-endian binary</td>
+          <td>Training history across every run: format version (int32), corpus token count (int32), step count (int32), the float32 loss of each step, the int32 cumulative tokens-seen of each step, then the run-boundary count (int32) and each boundary (int32), and finally the bit-packed visited sets for corpus positions and vocabulary entries (each an int32 length followed by ceil(length/8) bytes). Read by <code>--resume</code> so the loss graph and coverage continue across runs; optional — a checkpoint without it starts a fresh history</td>
         </tr>
       </tbody>
     </table>
@@ -349,7 +358,8 @@ flowchart TB
       <code>--tokenizer</code>: the default <code>bpe</code> learns byte-pair merges up to
       <code>--vocab-size</code> tokens, while <code>char</code> uses one token per distinct character.
       Training progress (step and loss) is reported periodically, and on completion the parameter count,
-      vocabulary size, final loss, corpus token count (with chars/token), and checkpoint path are printed.
+      vocabulary size, final loss, corpus token count (with chars/token), and checkpoint path are printed,
+      along with how much of the corpus and vocabulary the randomly sampled batches actually visited.
       <code>--source</code> accepts either a path to a corpus file or literal text.
     </p>
     <p>
@@ -359,6 +369,22 @@ flowchart TB
       <code>--tokenizer</code>, and <code>--vocab-size</code> are ignored), and saved optimizer state is
       restored when present. For a <code>char</code> checkpoint the corpus may only contain characters that
       were in the original training corpus; a <code>bpe</code> checkpoint accepts any text.
+    </p>
+    <p>
+      <code>--loss-graph</code> writes a standalone HTML report of the run to the given path (parent
+      directories are created as needed). Every step's loss is recorded &mdash; not just the ones printed
+      to the console &mdash; and embedded in the page, which draws the raw series plus a smoothed trend
+      line on a canvas with hover readouts. A second chart tracks <strong>corpus coverage</strong>: because
+      batches are drawn from random offsets, the report shows the cumulative share of the corpus's token
+      positions that have been sampled at least once, so it is easy to see whether a run visits most of the
+      corpus or keeps re-treading the same windows. The run's configuration, corpus coverage, and vocabulary
+      coverage are tabulated below the charts. The file is self-contained (no external scripts or styles),
+      so it can be opened directly or served with <a href="web.html"><code>web serve-html</code></a>.
+      Because the series and visited sets are stored in the checkpoint's <code>history.bin</code>, a
+      <code>--resume</code> run graphs the whole history — every run against that checkpoint, not just
+      the latest — with a dashed divider at each resume point and coverage carried on from the positions
+      already visited. If the resumed corpus has a different token count the recorded positions no longer
+      apply, so coverage restarts from that run while the loss curve is still kept.
     </p>
 
     <div class="cmd-block">
@@ -390,6 +416,13 @@ flowchart TB
       <span class="opt"> --resume</span>
     </div>
 
+    <div class="cmd-block">
+      <span class="prompt">$ </span><span class="cmd">pbtk gpt train</span>
+      <span class="opt"> --source</span> <span class="val">shakespeare.txt</span>
+      <span class="opt"> --steps</span> <span class="val">2000</span>
+      <span class="opt"> --loss-graph</span> <span class="val">./loss.html</span>
+    </div>
+
     <table>
       <thead><tr><th>Option</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
       <tbody>
@@ -405,7 +438,8 @@ flowchart TB
         <tr><td><code>--vocab-size</code></td><td>No</td><td><code>512</code></td><td>Target vocabulary size for the <code>bpe</code> tokenizer (&ge; 256; ignored for <code>char</code>)</td></tr>
         <tr><td><code>--lr</code></td><td>No</td><td><code>0.0003</code></td><td>Learning rate</td></tr>
         <tr><td><code>--seed</code></td><td>No</td><td><code>1337</code></td><td>Random seed for reproducible runs</td></tr>
-        <tr><td><code>--resume</code></td><td>No</td><td><code>false</code></td><td>Resume training from the checkpoint in <code>--out</code> (architecture and tokenizer options are taken from the checkpoint)</td></tr>
+        <tr><td><code>--resume</code></td><td>No</td><td><code>false</code></td><td>Resume training from the checkpoint in <code>--out</code> (architecture, tokenizer options, and recorded training history are taken from the checkpoint)</td></tr>
+        <tr><td><code>--loss-graph</code></td><td>No</td><td>&mdash;</td><td>Path to write an HTML report graphing per-step training loss and corpus coverage</td></tr>
       </tbody>
     </table>
   </section>
@@ -473,8 +507,8 @@ flowchart LR
         <tr>
           <td><code>gpt train</code></td>
           <td><code>--source</code></td>
-          <td><code>--out</code>, <code>--steps</code>, <code>--batch-size</code>, <code>--block-size</code>, <code>--n-embd</code>, <code>--n-head</code>, <code>--n-layer</code>, <code>--tokenizer</code>, <code>--vocab-size</code>, <code>--lr</code>, <code>--seed</code>, <code>--resume</code></td>
-          <td>Training progress, then summary with parameter count, vocab size, final loss, corpus token count, and checkpoint path</td>
+          <td><code>--out</code>, <code>--steps</code>, <code>--batch-size</code>, <code>--block-size</code>, <code>--n-embd</code>, <code>--n-head</code>, <code>--n-layer</code>, <code>--tokenizer</code>, <code>--vocab-size</code>, <code>--lr</code>, <code>--seed</code>, <code>--resume</code>, <code>--loss-graph</code></td>
+          <td>Training progress, then summary with parameter count, vocab size, final loss, corpus token count, checkpoint path, and corpus/vocabulary coverage; an HTML loss and coverage report when <code>--loss-graph</code> is given</td>
         </tr>
         <tr>
           <td><code>gpt complete</code></td>


### PR DESCRIPTION
## Summary

`pbtk gpt train --loss-graph <path>` writes a standalone HTML report of the training run.

- **Loss chart** — every step's loss is recorded (not just the ones printed to the console), drawn raw plus an EMA-smoothed trend line.
- **Corpus coverage chart** — batches are sampled from random offsets, so the run now tracks which corpus positions and vocabulary entries were actually visited, and graphs the cumulative share of the corpus sampled at least once. The train summary reports it too: `Sampled 21,140/21,293 corpus tokens (99.3%), 27/27 vocab entries (100.0%)`.
- **History survives `--resume`** — the series, run boundaries, and bit-packed visited sets are persisted to a new `history.bin` in the checkpoint, so a resumed run graphs every run against that checkpoint with a dashed divider at each resume point and coverage carried forward. Resuming against a differently sized corpus restarts coverage (the recorded positions no longer apply) but keeps the loss curve.

The page is self-contained — no external scripts, styles, or fonts — canvas-drawn with hover readouts, responsive, and theme-aware, so it can be opened directly or served with `web serve-html`.

New services follow the existing interface-based pattern: `ILossGraphService`/`LossGraphService`, injected into `GptTrainComponent` alongside `ICheckpointService`.

## Test plan

- [x] Tests pass: `dotnet test` — 579 passed, 0 failed
- [x] Version bumped in csproj (6.7.0 → 6.8.0, minor: new feature)
- [x] `docs/gpt.html` updated: train section, options table, command reference, architecture table/diagram, training pipeline, checkpoint format
- [x] End-to-end check on a 21k-token corpus: 150 steps → 85.6% coverage, then `--resume` for 150 more → 300 loss points, 300 coverage points, `RUN_BOUNDARIES = [150,300]`, coverage 99.3% carried forward
- [x] Generated page JS verified with `node --check` and a stub-DOM smoke run (both charts draw, hover and run dividers work)

New tests cover `history.bin` round-tripping (including a partial trailing byte in the packed sets, empty history, and unknown format version), history append on resume, coverage reset when the corpus length changes, per-step recording, and CLI integration asserting a resumed graph contains both runs with the first run's losses verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)